### PR TITLE
Introducing timezone keyword

### DIFF
--- a/src/Mailcode/Commands/Keywords.php
+++ b/src/Mailcode/Commands/Keywords.php
@@ -34,6 +34,7 @@ class Mailcode_Commands_Keywords
     public const TYPE_NO_TRACKING = 'no-tracking:';
     public const TYPE_BREAK_AT = 'break-at:';
     public const TYPE_COUNT = 'count:';
+    public const TYPE_TIMEZONE = 'timezone:';
 
     /**
      * @return string[]
@@ -53,7 +54,8 @@ class Mailcode_Commands_Keywords
             self::TYPE_ABSOLUTE,
             self::TYPE_NO_TRACKING,
             self::TYPE_BREAK_AT,
-            self::TYPE_COUNT
+            self::TYPE_COUNT,
+            self::TYPE_TIMEZONE
         );
     }
 }

--- a/src/Mailcode/Factory/CommandSets/Set/Show/Date.php
+++ b/src/Mailcode/Factory/CommandSets/Set/Show/Date.php
@@ -38,12 +38,12 @@ class Date extends Mailcode_Factory_CommandSets_Set
         $timezone = '';
         if (!empty($timezoneString)) {
             $timezone = sprintf(
-                ' %s',
+                ' timezone: %s',
                 $this->quoteString($timezoneString)
             );
         } else if (!empty($timezoneVariable)) {
             $timezone = sprintf(
-                ' %s',
+                ' timezone: %s',
                 $timezoneVariable
             );
         }

--- a/src/Mailcode/Traits/Commands/Validation/TimezoneTrait.php
+++ b/src/Mailcode/Traits/Commands/Validation/TimezoneTrait.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Mailcode\Traits\Commands\Validation;
 
 use Mailcode\Interfaces\Commands\Validation\TimezoneInterface;
+use Mailcode\Mailcode_Commands_Keywords;
 use Mailcode\Mailcode_Parser_Statement_Tokenizer_Token;
 use Mailcode\Mailcode_Parser_Statement_Tokenizer_Token_StringLiteral;
 use Mailcode\Mailcode_Parser_Statement_Tokenizer_Token_Variable;
@@ -32,11 +33,16 @@ trait TimezoneTrait
 
     protected function validateSyntax_check_timezone(): void
     {
+        $this->timezoneToken = $this->requireParams()->getInfo()->getTokenForKeyword(Mailcode_Commands_Keywords::TYPE_TIMEZONE);
+
+        $val = $this->validator->createKeyword(Mailcode_Commands_Keywords::TYPE_TIMEZONE);
+
+        $this->timezoneEnabled = $val->isValid() && $this->timezoneToken != null;;
+
+        // ---
         $tokens = $this->requireParams()->getInfo()->getTokens();
 
-        if (count($tokens) > 2) {
-            $this->timezoneToken = $tokens[2];
-
+        if ($this->timezoneEnabled) {
             if (!$this->timezoneToken instanceof Mailcode_Parser_Statement_Tokenizer_Token_StringLiteral &&
                 !$this->timezoneToken instanceof Mailcode_Parser_Statement_Tokenizer_Token_Variable) {
                 $this->validationResult->makeError(
@@ -45,8 +51,6 @@ trait TimezoneTrait
                 );
                 return;
             }
-
-            $this->timezoneEnabled = true;
         }
     }
 

--- a/tests/testsuites/Commands/Types/ShowDate.php
+++ b/tests/testsuites/Commands/Types/ShowDate.php
@@ -47,7 +47,7 @@ final class Mailcode_ShowDateTests extends MailcodeTestCase
             ),
             array(
                 'label' => 'With valid variable and only timezone',
-                'string' => '{showdate: $foo_bar "US/Eastern"}',
+                'string' => '{showdate: $foo_bar timezone: "US/Eastern"}',
                 'valid' => false,
                 'code' => Mailcode_Date_FormatInfo::VALIDATION_INVALID_FORMAT_CHARACTER
             ),
@@ -59,7 +59,7 @@ final class Mailcode_ShowDateTests extends MailcodeTestCase
             ),
             array(
                 'label' => 'With valid variable, valid format string, invalid timezone',
-                'string' => '{showdate: $foo_bar "Y-m-d H:i:s" US/Eastern}',
+                'string' => '{showdate: $foo_bar "Y-m-d H:i:s" timezone: US/Eastern}',
                 'valid' => false,
                 'code' => Mailcode_Commands_Command::VALIDATION_INVALID_PARAMS_STATEMENT
             ),
@@ -71,19 +71,43 @@ final class Mailcode_ShowDateTests extends MailcodeTestCase
             ),
             array(
                 'label' => 'With valid variable, valid format string, valid timezone',
-                'string' => '{showdate: $foo_bar "Y-m-d H:i:s" "US/Eastern"}',
+                'string' => '{showdate: $foo_bar "Y-m-d H:i:s" timezone: "US/Eastern"}',
                 'valid' => true,
                 'code' => 0
             ),
             array(
                 'label' => 'With valid variable, valid format string, valid variable timezone',
-                'string' => '{showdate: $foo_bar "Y-m-d H:i:s" $FOO.TIMEZONE}',
+                'string' => '{showdate: $foo_bar "Y-m-d H:i:s" timezone: $FOO.TIMEZONE}',
                 'valid' => true,
                 'code' => 0
             ),
             array(
-                'label' => 'With valid variable, valid format string, valid variable timezone',
-                'string' => '{showdate: $foo_bar "Y-m-d H:i:s" 13}',
+                'label' => 'With valid variable, valid format string, valid variable timezone, and additional keyword behind',
+                'string' => '{showdate: $foo_bar "Y-m-d H:i:s" timezone: $FOO.TIMEZONE urlencode:}',
+                'valid' => true,
+                'code' => 0
+            ),
+            array(
+                'label' => 'With valid variable, valid format string, and additional keyword behind',
+                'string' => '{showdate: $foo_bar "Y-m-d H:i:s" urlencode:}',
+                'valid' => true,
+                'code' => 0
+            ),
+            array(
+                'label' => 'With valid variable, valid format string, valid variable timezone, and additional keyword in front',
+                'string' => '{showdate: urlencode: $foo_bar "Y-m-d H:i:s" timezone: "Europe/Berlin"}',
+                'valid' => true,
+                'code' => 0
+            ),
+            array(
+                'label' => 'With valid variable, valid format string, and mixup in timezone and additional keyword',
+                'string' => '{showdate: $foo_bar "Y-m-d H:i:s" timezone: urlencode: "Europe/Berlin"}',
+                'valid' => false,
+                'code' => TimezoneInterface::VALIDATION_TIMEZONE_CODE_WRONG_TYPE
+            ),
+            array(
+                'label' => 'With valid variable, valid format string, invalid variable timezone',
+                'string' => '{showdate: $foo_bar "Y-m-d H:i:s" timezone: 13}',
                 'valid' => false,
                 'code' => TimezoneInterface::VALIDATION_TIMEZONE_CODE_WRONG_TYPE
             )
@@ -140,7 +164,7 @@ final class Mailcode_ShowDateTests extends MailcodeTestCase
 
     public function test_timezoneString(): void
     {
-        $cmd = Mailcode::create()->parseString('{showdate: $FOO "Y.m.d" "Europe/Paris"}')->getFirstCommand();
+        $cmd = Mailcode::create()->parseString('{showdate: $FOO "Y.m.d" timezone: "Europe/Paris"}')->getFirstCommand();
 
         $this->assertNotNull($cmd);
         $this->assertInstanceOf(Mailcode_Commands_Command_ShowDate::class, $cmd);
@@ -156,7 +180,7 @@ final class Mailcode_ShowDateTests extends MailcodeTestCase
 
     public function test_timezoneVariable(): void
     {
-        $cmd = Mailcode::create()->parseString('{showdate: $FOO "Y.m.d" $TIMEZONE}')->getFirstCommand();
+        $cmd = Mailcode::create()->parseString('{showdate: $FOO "Y.m.d" timezone: $TIMEZONE}')->getFirstCommand();
 
         $this->assertNotNull($cmd);
         $this->assertInstanceOf(Mailcode_Commands_Command_ShowDate::class, $cmd);

--- a/tests/testsuites/Factory/Commands/ShowDate.php
+++ b/tests/testsuites/Factory/Commands/ShowDate.php
@@ -10,36 +10,58 @@ final class Factory_ShowDateTests extends FactoryTestCase
     {
         return Mailcode_Commands_Command_ShowDate::class;
     }
-    
+
     public function test_showDate()
     {
         $this->runCommand(
             'Variable name without $',
             function() { return Mailcode_Factory::show()->date('VAR.NAME'); }
         );
-        
+
         $this->runCommand(
             'Variable name with $',
             function() { return Mailcode_Factory::show()->date('$VAR.NAME'); }
         );
-        
+
         $this->runCommand(
             'With format string',
             function() { return Mailcode_Factory::show()->date('$VAR.NAME', 'd.m.Y'); }
         );
+
+        $this->runCommand(
+            'With timezone string',
+            function() { return Mailcode_Factory::show()->date('$VAR.NAME', 'd.m.Y', 'Europe/Berlin'); }
+        );
+
+        $this->runCommand(
+            'With timezone variable',
+            function() { return Mailcode_Factory::show()->date('$VAR.NAME', 'd.m.Y', null, '$TIME.ZONE'); }
+        );
+
+        $this->runCommand(
+            'With timezone variable',
+            function() { return Mailcode_Factory::show()->date('$VAR.NAME', 'd.m.Y', null, '$TIME.ZONE'); }
+        );
     }
-    
+
     public function test_showDate_variableError()
     {
         $this->expectException(Mailcode_Factory_Exception::class);
-        
+
         Mailcode_Factory::show()->date('0INVALIDVAR');
     }
-    
+
     public function test_showDate_formatError()
     {
         $this->expectException(Mailcode_Factory_Exception::class);
-        
+
         Mailcode_Factory::show()->date('VAR.NAME', 'd.m.Z');
+    }
+
+    public function test_showDate_timezone_variableError()
+    {
+        $this->expectException(Mailcode_Factory_Exception::class);
+
+        Mailcode_Factory::show()->date('VAR.NAME', 'd.m.Y',null, 'TIME.ZONE');
     }
 }

--- a/tests/testsuites/Translator/ApacheVelocity.php
+++ b/tests/testsuites/Translator/ApacheVelocity.php
@@ -63,18 +63,118 @@ ${CUSTOMER.CUSTOMER_ID}
      * specific internal date format when they are translated,
      * while not translating them manually.
      */
-    public function test_translateSafeguard_dates() : void
+    public function test_translateSafeguard_dates(): void
     {
         $subject = '{showdate: $FOO.BAR "d.m.Y"}';
+
         $internalFormat = 'yyyy-MM-dd';
-        $expected = '${time.input("'.$internalFormat.'", $FOO.BAR).output("dd.MM.yyyy")}';
+        $expected = '${time.input("' . $internalFormat . '", $FOO.BAR).output("dd.MM.yyyy")}';
 
         $syntax = $this->translator->createSyntax('ApacheVelocity');
         $safeguard = Mailcode::create()->createSafeguard($subject);
         $dateCommands = $safeguard->getCollection()->getShowDateCommands();
 
-        foreach($dateCommands as $dateCommand)
-        {
+        foreach ($dateCommands as $dateCommand) {
+            $dateCommand->setTranslationParam('internal_format', $internalFormat);
+        }
+
+        $result = $syntax->translateSafeguard($safeguard);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function test_showDate_keyword_behind(): void
+    {
+        $subject = '{showdate: $FOO.BAR "Y-m-d" urlencode:}';
+
+        $internalFormat = 'yyyy-MM-dd';
+        $expected = '${esc.url($time.input("' . $internalFormat . '", $FOO.BAR).output("yyyy-MM-dd"))}';
+
+        $syntax = $this->translator->createSyntax('ApacheVelocity');
+        $safeguard = Mailcode::create()->createSafeguard($subject);
+        $dateCommands = $safeguard->getCollection()->getShowDateCommands();
+
+        foreach ($dateCommands as $dateCommand) {
+            $dateCommand->setTranslationParam('internal_format', $internalFormat);
+        }
+
+        $result = $syntax->translateSafeguard($safeguard);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function test_showDate_keyword_before(): void
+    {
+        $subject = '{showdate: urlencode: $FOO.BAR "Y-m-d"}';
+
+        $internalFormat = 'yyyy-MM-dd';
+        $expected = '${esc.url($time.input("' . $internalFormat . '", $FOO.BAR).output("yyyy-MM-dd"))}';
+
+        $syntax = $this->translator->createSyntax('ApacheVelocity');
+        $safeguard = Mailcode::create()->createSafeguard($subject);
+        $dateCommands = $safeguard->getCollection()->getShowDateCommands();
+
+        foreach ($dateCommands as $dateCommand) {
+            $dateCommand->setTranslationParam('internal_format', $internalFormat);
+        }
+
+        $result = $syntax->translateSafeguard($safeguard);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function test_showDate_keyword_behind_timezone(): void
+    {
+        $subject = '{showdate: $FOO.BAR "Y-m-d" timezone: "Europe/Berlin" urlencode:}';
+
+        $internalFormat = 'yyyy-MM-dd';
+        $expected = '${esc.url($time.input("' . $internalFormat . '", $FOO.BAR).output("yyyy-MM-dd").zone("Europe/Berlin"))}';
+
+        $syntax = $this->translator->createSyntax('ApacheVelocity');
+        $safeguard = Mailcode::create()->createSafeguard($subject);
+        $dateCommands = $safeguard->getCollection()->getShowDateCommands();
+
+        foreach ($dateCommands as $dateCommand) {
+            $dateCommand->setTranslationParam('internal_format', $internalFormat);
+        }
+
+        $result = $syntax->translateSafeguard($safeguard);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function test_showDate_keyword_before_timezone(): void
+    {
+        $subject = '{showdate: urlencode: $FOO.BAR "Y-m-d" timezone: "Europe/Berlin"}';
+
+        $internalFormat = 'yyyy-MM-dd';
+        $expected = '${esc.url($time.input("' . $internalFormat . '", $FOO.BAR).output("yyyy-MM-dd").zone("Europe/Berlin"))}';
+
+        $syntax = $this->translator->createSyntax('ApacheVelocity');
+        $safeguard = Mailcode::create()->createSafeguard($subject);
+        $dateCommands = $safeguard->getCollection()->getShowDateCommands();
+
+        foreach ($dateCommands as $dateCommand) {
+            $dateCommand->setTranslationParam('internal_format', $internalFormat);
+        }
+
+        $result = $syntax->translateSafeguard($safeguard);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function test_showDate_keyword_between_timezone(): void
+    {
+        $subject = '{showdate: $FOO.BAR "Y-m-d" urlencode: timezone: "Europe/Berlin"}';
+
+        $internalFormat = 'yyyy-MM-dd';
+        $expected = '${esc.url($time.input("' . $internalFormat . '", $FOO.BAR).output("yyyy-MM-dd").zone("Europe/Berlin"))}';
+
+        $syntax = $this->translator->createSyntax('ApacheVelocity');
+        $safeguard = Mailcode::create()->createSafeguard($subject);
+        $dateCommands = $safeguard->getCollection()->getShowDateCommands();
+
+        foreach ($dateCommands as $dateCommand) {
             $dateCommand->setTranslationParam('internal_format', $internalFormat);
         }
 


### PR DESCRIPTION
`TimezoneTrait` now uses a dedicated keyword `timezone:` that needs a parameter analogue to `BreakAtTrait`.

Using a keyword seems to be more future-proof than having to search for "the second occurrence of either a variable or a string", and allows for a more flexible syntax.

The "second occurrence" approach would have allowed this syntax:
```
{showdate: $FOO.BAR "Y-m-d" urlencode: "Europe/Berlin"}
```
which might be confusing.

So, the actual syntax would be
```
{showdate: $FOO.BAR "Y-m-d" urlencode: timezone: "Europe/Berlin"}
```
