### PR TITLE
Setvar count lists

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v3.2.3 - SetVar update
+- SetVar Command: Fixed the Velocity translation for counting single variables.
+
 ### v3.2.2 - Fixed a test
 - Tests: Fixed a minor highlighting test not updated after v3.2.1.
 

--- a/src/Mailcode/Translator/Syntax/ApacheVelocity/SetVariable.php
+++ b/src/Mailcode/Translator/Syntax/ApacheVelocity/SetVariable.php
@@ -24,15 +24,11 @@ class Mailcode_Translator_Syntax_ApacheVelocity_SetVariable extends Mailcode_Tra
     {
         $assignmentString = $command->getAssignmentString();
 
-        if ($command->isCountEnabled()) {
-            $variable = $command->getCountVariable();
-
-            if ($variable != null) {
-                $assignmentString = sprintf(
-                    '$map.of(%s).keys("%s").count()',
-                    dollarize($variable->getPath()),
-                    $variable->getName()
-                );
+        if ($command->isCountEnabled())
+        {
+            $result = $this->buildCountAssignment($command);
+            if($result !== null) {
+                $assignmentString = $result;
             }
         }
 
@@ -40,6 +36,28 @@ class Mailcode_Translator_Syntax_ApacheVelocity_SetVariable extends Mailcode_Tra
             '#set(%s = %s)',
             $command->getVariable()->getFullName(),
             $assignmentString
+        );
+    }
+
+    private function buildCountAssignment(Mailcode_Commands_Command_SetVariable $command) : ?string
+    {
+        $variable = $command->getCountVariable();
+
+        if ($variable === null) {
+            return null;
+        }
+
+        if($variable->hasPath()) {
+            return sprintf(
+                '$map.of(%s).keys("%s").count()',
+                dollarize($variable->getPath()),
+                $variable->getName()
+            );
+        }
+
+        return sprintf(
+            '$map.of(%s).count()',
+            dollarize($variable->getName())
         );
     }
 }

--- a/src/Mailcode/Variables/Variable.php
+++ b/src/Mailcode/Variables/Variable.php
@@ -60,7 +60,7 @@ class Mailcode_Variables_Variable
    /**
     * @var array<string>
     */
-    protected $validations = array(
+    protected array $validations = array(
         'number_path',
         'number_name',
         'underscore_path',
@@ -197,7 +197,12 @@ class Mailcode_Variables_Variable
             }*/
         }
     }
-    
+
+    public function hasPath() : bool
+    {
+        return $this->getPath() !== '';
+    }
+
     protected function validate_number_path() : void
     {
         $this->validateNumber($this->path, self::VALIDATION_ERROR_PATH_NUMERIC);
@@ -220,7 +225,7 @@ class Mailcode_Variables_Variable
     
     protected function validateNumber(string $value, int $errorCode) : void
     {
-        if(!is_numeric(substr($value, 0, 1)))
+        if(empty($value) || !is_numeric($value[0]))
         {
             return;
         }

--- a/tests/testsuites/Translator/Commands/SetVariableTests.php
+++ b/tests/testsuites/Translator/Commands/SetVariableTests.php
@@ -38,6 +38,11 @@ final class SetVariableTests extends VelocityTestCase
                 'label' => 'Count variable with path only',
                 'mailcode' => Mailcode_Factory::set()->var('FOO', '$BAR.COUNT', true, true),
                 'expected' => '#set($FOO = $map.of($BAR).keys("COUNT").count())'
+            ),
+            array(
+                'label' => 'Count and source variables with path only',
+                'mailcode' => Mailcode_Factory::set()->var('FOO', '$BAR', true, true),
+                'expected' => '#set($FOO = $map.of($BAR).count())'
             )
         );
 


### PR DESCRIPTION
This adds the alternate `$map.of($BAR).count()` syntax to count lists without specifying a key.