### PR TITLE
introducing showprice command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,8 @@ update composer.lock: composer.json
 autoload composer.lock: composer.json
 	/usr/bin/php /usr/bin/composer dumpautoload
 
-testsuite: composer.lock
-ifdef testsuite
-	vendor/bin/phpunit --testsuite $(testsuite)
-else
-	@echo you must supply a testsuite
-endif
+test: composer.lock
+	vendor/bin/phpunit --verbose --testsuite all
 
 phpstan:
 	vendor/bin/phpstan analyse -c tests/phpstan/config.neon -l 9 --memory-limit=900M > tests/phpstan/result.txt

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+### v3.4.0 - Added ShowPrice command
+- Commands: Added the `{showprice}` command to format numbers as prices.
+- Traits: Added the `AbsoluteKeywordTrait`.
+- Dependencies: Updated AppLocalization to [v1.5.0](https://github.com/Mistralys/application-localization/releases/tag/1.5.0).
+
 ### v3.3.2 - Minor update
 - HubL: Added type casting to `float` for number comparisons.
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 	"require" : 
 	{
 		"mistralys/application-utils" : ">=2.1.2",
-		"mistralys/application-localization" : ">=1.4",
+		"mistralys/application-localization" : ">=1.5",
 		"giggsey/libphonenumber-for-php": "^8.12",
 		"monolog/monolog" : ">=2.7",
 		"ext-json": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c8d3be5050197efa04254d590fe95ea3",
+    "content-hash": "b7cf0d9cd608fd80ba790cd507fa71de",
     "packages": [
         {
             "name": "geshi/geshi",
@@ -54,34 +54,36 @@
         },
         {
             "name": "giggsey/libphonenumber-for-php",
-            "version": "8.13.36",
+            "version": "8.13.48",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/libphonenumber-for-php.git",
-                "reference": "9ca4179e4332d21578cb29f0c0406f0a2b8803e3"
+                "reference": "0965dd46e34934ca24922be75f940defb213f73c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/9ca4179e4332d21578cb29f0c0406f0a2b8803e3",
-                "reference": "9ca4179e4332d21578cb29f0c0406f0a2b8803e3",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/0965dd46e34934ca24922be75f940defb213f73c",
+                "reference": "0965dd46e34934ca24922be75f940defb213f73c",
                 "shasum": ""
             },
             "require": {
-                "giggsey/locale": "^1.7|^2.0",
-                "php": ">=5.3.2",
+                "giggsey/locale": "^2.0",
+                "php": "^7.4|^8.0",
                 "symfony/polyfill-mbstring": "^1.17"
             },
             "replace": {
                 "giggsey/libphonenumber-for-php-lite": "self.version"
             },
             "require-dev": {
-                "pear/pear-core-minimal": "^1.9",
+                "friendsofphp/php-cs-fixer": "^3.64",
+                "pear/pear-core-minimal": "^1.10",
                 "pear/pear_exception": "^1.0",
-                "pear/versioncontrol_git": "^0.5",
-                "phing/phing": "^2.7",
-                "php-coveralls/php-coveralls": "^1.0|^2.0",
-                "symfony/console": "^2.8|^3.0|^v4.4|^v5.2",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
+                "pear/versioncontrol_git": "^0.7",
+                "phing/phing": "^3.0",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/console": "^v5.2",
+                "symfony/var-exporter": "^5.2"
             },
             "type": "library",
             "extra": {
@@ -125,7 +127,7 @@
                 "issues": "https://github.com/giggsey/libphonenumber-for-php/issues",
                 "source": "https://github.com/giggsey/libphonenumber-for-php"
             },
-            "time": "2024-05-03T06:27:03+00:00"
+            "time": "2024-10-22T09:06:42+00:00"
         },
         {
             "name": "giggsey/locale",
@@ -183,24 +185,29 @@
         },
         {
             "name": "mistralys/application-localization",
-            "version": "1.4.1",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Mistralys/application-localization.git",
-                "reference": "ff0cce325c07a1999b1ddde567f4d133fc82ee82"
+                "reference": "2600cb9a1fef79294e47f830532ae0a87e923308"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Mistralys/application-localization/zipball/ff0cce325c07a1999b1ddde567f4d133fc82ee82",
-                "reference": "ff0cce325c07a1999b1ddde567f4d133fc82ee82",
+                "url": "https://api.github.com/repos/Mistralys/application-localization/zipball/2600cb9a1fef79294e47f830532ae0a87e923308",
+                "reference": "2600cb9a1fef79294e47f830532ae0a87e923308",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "mistralys/application-utils": ">=1.2.0",
+                "mistralys/application-utils": ">=3.0.5",
+                "mistralys/application-utils-collections": ">=1.1.2",
+                "mistralys/application-utils-core": ">=2.3.1",
+                "mistralys/changelog-parser": ">=1.0.2",
+                "mistralys/html_quickform2": ">=2.3.5",
                 "mistralys/jtokenizer": ">=1.0.1",
-                "php": ">=7.3"
+                "mistralys/php-sprintf-parser": "^1.0",
+                "php": ">=7.4"
             },
             "require-dev": {
                 "phpstan/phpstan": "^0.12",
@@ -232,22 +239,22 @@
             "description": "PHP and Javascript localization library.",
             "support": {
                 "issues": "https://github.com/Mistralys/application-localization/issues",
-                "source": "https://github.com/Mistralys/application-localization/tree/1.4.1"
+                "source": "https://github.com/Mistralys/application-localization/tree/1.5.0"
             },
-            "time": "2021-08-10T11:40:20+00:00"
+            "time": "2024-10-22T14:05:08+00:00"
         },
         {
             "name": "mistralys/application-utils",
-            "version": "3.0.4",
+            "version": "3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Mistralys/application-utils.git",
-                "reference": "eb5f5520237874488ffeff0f2a21575a59495963"
+                "reference": "7923ba94c22edb6b59ba398f29f0fde6c60e6266"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Mistralys/application-utils/zipball/eb5f5520237874488ffeff0f2a21575a59495963",
-                "reference": "eb5f5520237874488ffeff0f2a21575a59495963",
+                "url": "https://api.github.com/repos/Mistralys/application-utils/zipball/7923ba94c22edb6b59ba398f29f0fde6c60e6266",
+                "reference": "7923ba94c22edb6b59ba398f29f0fde6c60e6266",
                 "shasum": ""
             },
             "require": {
@@ -294,25 +301,73 @@
             "description": "Drop-in utilities for PHP applications.",
             "support": {
                 "issues": "https://github.com/Mistralys/application-utils/issues",
-                "source": "https://github.com/Mistralys/application-utils/tree/3.0.4"
+                "source": "https://github.com/Mistralys/application-utils/tree/3.0.5"
             },
-            "time": "2023-11-29T10:32:16+00:00"
+            "time": "2024-07-30T07:14:10+00:00"
         },
         {
-            "name": "mistralys/application-utils-core",
-            "version": "1.1.4",
+            "name": "mistralys/application-utils-collections",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Mistralys/application-utils-core.git",
-                "reference": "d7eda468c7e2f5286f00ec74ce870595f48d1362"
+                "url": "https://github.com/Mistralys/application-utils-collections.git",
+                "reference": "99a7c24e351ba54b4f95c128b9dc7dac2e4d7626"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Mistralys/application-utils-core/zipball/d7eda468c7e2f5286f00ec74ce870595f48d1362",
-                "reference": "d7eda468c7e2f5286f00ec74ce870595f48d1362",
+                "url": "https://api.github.com/repos/Mistralys/application-utils-collections/zipball/99a7c24e351ba54b4f95c128b9dc7dac2e4d7626",
+                "reference": "99a7c24e351ba54b4f95c128b9dc7dac2e4d7626",
                 "shasum": ""
             },
             "require": {
+                "mistralys/application-utils-core": ">=2.2.3",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "phpstan/phpstan": ">=1.10",
+                "phpunit/phpunit": ">=9.6"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Mordziol",
+                    "email": "s.mordziol@mistralys.eu",
+                    "homepage": "https://www.mistralys.eu",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Interfaces, traits and classes for handling static item collections, similar to Enums and with useful getter methods.",
+            "support": {
+                "issues": "https://github.com/Mistralys/application-utils-collections/issues",
+                "source": "https://github.com/Mistralys/application-utils-collections/tree/1.1.2"
+            },
+            "time": "2024-07-25T14:59:47+00:00"
+        },
+        {
+            "name": "mistralys/application-utils-core",
+            "version": "2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Mistralys/application-utils-core.git",
+                "reference": "6c9b8490979ce727c45aae26b0e6d9b2d7fa9307"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Mistralys/application-utils-core/zipball/6c9b8490979ce727c45aae26b0e6d9b2d7fa9307",
+                "reference": "6c9b8490979ce727c45aae26b0e6d9b2d7fa9307",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
                 "ext-curl": "*",
                 "ext-json": "*",
                 "ext-mbstring": "*",
@@ -352,9 +407,124 @@
             "description": "Drop-in utilities for PHP applications.",
             "support": {
                 "issues": "https://github.com/Mistralys/application-utils-core/issues",
-                "source": "https://github.com/Mistralys/application-utils-core/tree/1.1.4"
+                "source": "https://github.com/Mistralys/application-utils-core/tree/2.3.1"
             },
-            "time": "2024-03-27T08:43:45+00:00"
+            "time": "2024-10-17T12:47:31+00:00"
+        },
+        {
+            "name": "mistralys/changelog-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Mistralys/changelog-parser.git",
+                "reference": "0576433b5e26adeb368744ca1d1cd6d0b26a1580"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Mistralys/changelog-parser/zipball/0576433b5e26adeb368744ca1d1cd6d0b26a1580",
+                "reference": "0576433b5e26adeb368744ca1d1cd6d0b26a1580",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "mistralys/application-utils": ">=2.3.2",
+                "mistralys/version-parser": ">=2.0",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "phpstan/phpstan": ">=1.9.2",
+                "phpstan/phpstan-phpunit": ">=1.3.11",
+                "phpunit/phpunit": ">=9.5.26",
+                "roave/security-advisories": "dev-latest"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Mordziol",
+                    "email": "s.mordziol@mistralys.eu",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP library to parse Markdown-formatted change log files.",
+            "support": {
+                "issues": "https://github.com/Mistralys/changelog-parser/issues",
+                "source": "https://github.com/Mistralys/changelog-parser/tree/1.0.2"
+            },
+            "time": "2023-10-17T08:07:48+00:00"
+        },
+        {
+            "name": "mistralys/html_quickform2",
+            "version": "2.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Mistralys/HTML_QuickForm2.git",
+                "reference": "773d5cc82826ead05f6b5ec8189620c6976e0a75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Mistralys/HTML_QuickForm2/zipball/773d5cc82826ead05f6b5ec8189620c6976e0a75",
+                "reference": "773d5cc82826ead05f6b5ec8189620c6976e0a75",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4",
+                "symfony/polyfill-php80": ">=v1.27.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": ">=1.10",
+                "phpunit/phpunit": ">=9.6"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "HTML"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Alexey Borzov",
+                    "email": "avb@php.net",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Bertrand Mansion",
+                    "email": "golgote@mamasam.com",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Sebastian Mordziol",
+                    "email": "s.mordziol@mistralys.eu",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Provides methods to create, validate and render HTML forms in PHP.",
+            "homepage": "https://github.com/Mistralys/HTML_QuickForm2",
+            "keywords": [
+                "Forms",
+                "javascript",
+                "quickform",
+                "validation",
+                "wizard"
+            ],
+            "support": {
+                "docs": "https://pear.php.net/manual/en/package.html.html-quickform2.php",
+                "issues": "https://github.com/Mistralys/HTML_QuickForm2/issues",
+                "source": "https://github.com/Mistralys/HTML_QuickForm2"
+            },
+            "time": "2024-02-12T10:06:20+00:00"
         },
         {
             "name": "mistralys/jtokenizer",
@@ -410,6 +580,101 @@
                 "source": "https://github.com/Mistralys/jtokenizer/tree/1.0.1"
             },
             "time": "2021-03-12T08:55:11+00:00"
+        },
+        {
+            "name": "mistralys/php-sprintf-parser",
+            "version": "1.0.0-beta.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Mistralys/php-sprintf-parser.git",
+                "reference": "5549c6764816bc1ed9741029c537f1f77c5c21b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Mistralys/php-sprintf-parser/zipball/5549c6764816bc1ed9741029c537f1f77c5c21b7",
+                "reference": "5549c6764816bc1ed9741029c537f1f77c5c21b7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Mordziol",
+                    "email": "s.mordziol@mistralys.eu",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Parser to find all sprintf format placeholders in a string, and get information on them.",
+            "support": {
+                "issues": "https://github.com/Mistralys/php-sprintf-parser/issues",
+                "source": "https://github.com/Mistralys/php-sprintf-parser/tree/1.0.0-beta.1"
+            },
+            "time": "2021-11-01T16:11:44+00:00"
+        },
+        {
+            "name": "mistralys/version-parser",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Mistralys/version-parser.git",
+                "reference": "6d0b87da1aecc11146299cf9b9f40d5a8d8d6ec8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Mistralys/version-parser/zipball/6d0b87da1aecc11146299cf9b9f40d5a8d8d6ec8",
+                "reference": "6d0b87da1aecc11146299cf9b9f40d5a8d8d6ec8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4",
+                "symfony/polyfill-php80": ">=v1.26.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": ">=0.12",
+                "phpunit/phpunit": ">=8.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Mordziol",
+                    "email": "s.mordziol@mistralys.eu",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Class used to parse version numbers.",
+            "support": {
+                "issues": "https://github.com/Mistralys/version-parser/issues",
+                "source": "https://github.com/Mistralys/version-parser/tree/2.1.1"
+            },
+            "time": "2023-12-19T07:17:05+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -670,20 +935,20 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.29.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec"
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
-                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-mbstring": "*"
@@ -730,7 +995,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -746,24 +1011,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.29.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "type": "library",
             "extra": {
@@ -810,7 +1075,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -826,7 +1091,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         }
     ],
     "packages-dev": [
@@ -902,16 +1167,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.1",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
                 "shasum": ""
             },
             "require": {
@@ -919,11 +1184,12 @@
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
                 "doctrine/collections": "^1.6.8",
                 "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
@@ -949,7 +1215,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
             },
             "funding": [
                 {
@@ -957,20 +1223,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-08T13:26:56+00:00"
+            "time": "2024-06-12T14:39:25+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.0.2",
+            "version": "v5.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13"
+                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/139676794dc1e9231bf7bcd123cfc0c99182cb13",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/8eea230464783aa9671db8eea6f8c6ac5285794b",
+                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b",
                 "shasum": ""
             },
             "require": {
@@ -981,7 +1247,7 @@
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -1013,9 +1279,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.3.1"
             },
-            "time": "2024-03-05T20:51:40+00:00"
+            "time": "2024-10-08T18:51:32+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1137,16 +1403,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.67",
+            "version": "1.12.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "16ddbe776f10da6a95ebd25de7c1dbed397dc493"
+                "reference": "dc2b9976bd8b0f84ec9b0e50cc35378551de7af0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/16ddbe776f10da6a95ebd25de7c1dbed397dc493",
-                "reference": "16ddbe776f10da6a95ebd25de7c1dbed397dc493",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dc2b9976bd8b0f84ec9b0e50cc35378551de7af0",
+                "reference": "dc2b9976bd8b0f84ec9b0e50cc35378551de7af0",
                 "shasum": ""
             },
             "require": {
@@ -1191,39 +1457,39 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-16T07:22:02+00:00"
+            "time": "2024-10-18T11:12:07+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.31",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.18 || ^5.0",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
                 "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -1232,7 +1498,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -1261,7 +1527,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
             "funding": [
                 {
@@ -1269,7 +1535,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:37:42+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1514,45 +1780,45 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.19",
+            "version": "9.6.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8"
+                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1a54a473501ef4cdeaae4e06891674114d79db8",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
+                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.12.0",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.28",
-                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
                 "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
                 "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.6",
+                "sebastian/global-state": "^5.0.7",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -1597,7 +1863,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.21"
             },
             "funding": [
                 {
@@ -1613,7 +1879,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-05T04:35:58+00:00"
+            "time": "2024-09-19T10:50:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,7 @@
          stopOnFailure="false"
          bootstrap="tests/bootstrap.php">
     <testsuites>
-        <testsuite name="All Suites">
+        <testsuite name="all">
             <directory suffix=".php">./tests/testsuites</directory>
         </testsuite>
     </testsuites>

--- a/src/Mailcode/Commands/Command/ShowNumber.php
+++ b/src/Mailcode/Commands/Command/ShowNumber.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Mailcode;
 
+use Mailcode\Interfaces\Commands\Validation\AbsoluteKeywordInterface;
+use Mailcode\Traits\Commands\Validation\AbsoluteKeywordTrait;
+
 /**
  * Mailcode command: show a date variable value.
  *
@@ -20,7 +23,10 @@ namespace Mailcode;
  */
 class Mailcode_Commands_Command_ShowNumber
     extends Mailcode_Commands_ShowBase
+    implements AbsoluteKeywordInterface
 {
+    use AbsoluteKeywordTrait;
+
     public const VALIDATION_PADDING_SEPARATOR_OVERFLOW = 72202;
     public const VALIDATION_INVALID_FORMAT_NUMBER = 72203;
     public const VALIDATION_INVALID_THOUSANDS_SEPARATOR = 72204;
@@ -37,11 +43,6 @@ class Mailcode_Commands_Command_ShowNumber
      */
     private string $formatString = Mailcode_Number_Info::DEFAULT_FORMAT;
 
-    /**
-     * @var Mailcode_Parser_Statement_Tokenizer_Token_Keyword|NULL
-     */
-    private ?Mailcode_Parser_Statement_Tokenizer_Token_Keyword $absoluteKeyword = null;
-
     public function getName(): string
     {
         return 'shownumber';
@@ -57,7 +58,7 @@ class Mailcode_Commands_Command_ShowNumber
         return array(
             Mailcode_Interfaces_Commands_Validation_Variable::VALIDATION_NAME_VARIABLE,
             'check_format',
-            'absolute'
+            AbsoluteKeywordInterface::VALIDATION_NAME
         );
     }
 
@@ -74,20 +75,6 @@ class Mailcode_Commands_Command_ShowNumber
 
         $token = array_pop($tokens);
         $this->parseFormatString($token->getText());
-    }
-
-    protected function validateSyntax_absolute(): void
-    {
-        $keywords = $this->requireParams()
-            ->getInfo()
-            ->getKeywords();
-
-        foreach ($keywords as $keyword) {
-            if ($keyword->getKeyword() === Mailcode_Commands_Keywords::TYPE_ABSOLUTE) {
-                $this->absoluteKeyword = $keyword;
-                break;
-            }
-        }
     }
 
     private function parseFormatString(string $format): void
@@ -113,29 +100,6 @@ class Mailcode_Commands_Command_ShowNumber
     public function getFormatString(): string
     {
         return $this->formatString;
-    }
-
-    public function isAbsolute(): bool
-    {
-        return isset($this->absoluteKeyword);
-    }
-
-    public function setAbsolute(bool $absolute): Mailcode_Commands_Command_ShowNumber
-    {
-        if ($absolute === false && isset($this->absoluteKeyword)) {
-            $this->requireParams()->getInfo()->removeKeyword($this->absoluteKeyword->getKeyword());
-            $this->absoluteKeyword = null;
-        }
-
-        if ($absolute === true && !isset($this->absoluteKeyword)) {
-            $this->requireParams()
-                ->getInfo()
-                ->addKeyword(Mailcode_Commands_Keywords::TYPE_ABSOLUTE);
-
-            $this->validateSyntax_absolute();
-        }
-
-        return $this;
     }
 
     /**

--- a/src/Mailcode/Commands/Command/ShowNumber.php
+++ b/src/Mailcode/Commands/Command/ShowNumber.php
@@ -18,7 +18,8 @@ namespace Mailcode;
  * @subpackage Commands
  * @author Sebastian Mordziol <s.mordziol@mistralys.eu>
  */
-class Mailcode_Commands_Command_ShowNumber extends Mailcode_Commands_ShowBase
+class Mailcode_Commands_Command_ShowNumber
+    extends Mailcode_Commands_ShowBase
 {
     public const VALIDATION_PADDING_SEPARATOR_OVERFLOW = 72202;
     public const VALIDATION_INVALID_FORMAT_NUMBER = 72203;
@@ -29,11 +30,11 @@ class Mailcode_Commands_Command_ShowNumber extends Mailcode_Commands_ShowBase
     public const VALIDATION_INVALID_DECIMALS_CHARS = 72208;
     public const VALIDATION_INVALID_DECIMAL_SEPARATOR = 72209;
     public const VALIDATION_SEPARATORS_SAME_CHARACTER = 72210;
-    
-   /**
-    * The default number format string.
-    * @var string
-    */
+
+    /**
+     * The default number format string.
+     * @var string
+     */
     private string $formatString = Mailcode_Number_Info::DEFAULT_FORMAT;
 
     /**
@@ -41,17 +42,17 @@ class Mailcode_Commands_Command_ShowNumber extends Mailcode_Commands_ShowBase
      */
     private ?Mailcode_Parser_Statement_Tokenizer_Token_Keyword $absoluteKeyword = null;
 
-    public function getName() : string
+    public function getName(): string
     {
         return 'shownumber';
     }
 
-    public function getLabel() : string
+    public function getLabel(): string
     {
         return t('Show number variable');
     }
 
-    protected function getValidations() : array
+    protected function getValidations(): array
     {
         return array(
             Mailcode_Interfaces_Commands_Validation_Variable::VALIDATION_NAME_VARIABLE,
@@ -60,44 +61,40 @@ class Mailcode_Commands_Command_ShowNumber extends Mailcode_Commands_ShowBase
         );
     }
 
-    protected function validateSyntax_check_format() : void
+    protected function validateSyntax_check_format(): void
     {
-         $tokens = $this->requireParams()
-             ->getInfo()
-             ->getStringLiterals();
-         
-         // no format specified? Use the default one.
-         if(empty($tokens))
-         {
-             return;
-         }
+        $tokens = $this->requireParams()
+            ->getInfo()
+            ->getStringLiterals();
 
-         $token = array_pop($tokens);
-         $this->parseFormatString($token->getText());
+        // no format specified? Use the default one.
+        if (empty($tokens)) {
+            return;
+        }
+
+        $token = array_pop($tokens);
+        $this->parseFormatString($token->getText());
     }
 
-    protected function validateSyntax_absolute() : void
+    protected function validateSyntax_absolute(): void
     {
         $keywords = $this->requireParams()
             ->getInfo()
             ->getKeywords();
 
-        foreach($keywords as $keyword)
-        {
-            if($keyword->getKeyword() === Mailcode_Commands_Keywords::TYPE_ABSOLUTE)
-            {
+        foreach ($keywords as $keyword) {
+            if ($keyword->getKeyword() === Mailcode_Commands_Keywords::TYPE_ABSOLUTE) {
                 $this->absoluteKeyword = $keyword;
                 break;
             }
         }
     }
 
-    private function parseFormatString(string $format) : void
+    private function parseFormatString(string $format): void
     {
         $result = new Mailcode_Number_Info($format);
 
-        if($result->isValid())
-        {
+        if ($result->isValid()) {
             $this->formatString = $format;
             return;
         }
@@ -107,37 +104,35 @@ class Mailcode_Commands_Command_ShowNumber extends Mailcode_Commands_ShowBase
             $result->getCode()
         );
     }
-    
-   /**
-    * Retrieves the format string used to format the number.
-    * 
-    * @return string
-    */
-    public function getFormatString() : string
+
+    /**
+     * Retrieves the format string used to format the number.
+     *
+     * @return string
+     */
+    public function getFormatString(): string
     {
         return $this->formatString;
     }
 
-    public function isAbsolute() : bool
+    public function isAbsolute(): bool
     {
         return isset($this->absoluteKeyword);
     }
 
-    public function setAbsolute(bool $absolute) : Mailcode_Commands_Command_ShowNumber
+    public function setAbsolute(bool $absolute): Mailcode_Commands_Command_ShowNumber
     {
-        if($absolute === false && isset($this->absoluteKeyword))
-        {
+        if ($absolute === false && isset($this->absoluteKeyword)) {
             $this->requireParams()->getInfo()->removeKeyword($this->absoluteKeyword->getKeyword());
             $this->absoluteKeyword = null;
         }
 
-        if($absolute === true && !isset($this->absoluteKeyword))
-        {
-             $this->requireParams()
-                 ->getInfo()
-                 ->addKeyword(Mailcode_Commands_Keywords::TYPE_ABSOLUTE);
+        if ($absolute === true && !isset($this->absoluteKeyword)) {
+            $this->requireParams()
+                ->getInfo()
+                ->addKeyword(Mailcode_Commands_Keywords::TYPE_ABSOLUTE);
 
-             $this->validateSyntax_absolute();
+            $this->validateSyntax_absolute();
         }
 
         return $this;
@@ -148,7 +143,7 @@ class Mailcode_Commands_Command_ShowNumber extends Mailcode_Commands_ShowBase
      *
      * @return Mailcode_Number_Info
      */
-    public function getFormatInfo() : Mailcode_Number_Info
+    public function getFormatInfo(): Mailcode_Number_Info
     {
         return new Mailcode_Number_Info($this->getFormatString());
     }

--- a/src/Mailcode/Commands/Command/ShowPrice.php
+++ b/src/Mailcode/Commands/Command/ShowPrice.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * File containing the {@see Mailcode_Commands_Command_ShowPrice} class.
+ *
+ * @package Mailcode
+ * @subpackage Commands
+ * @see Mailcode_Commands_Command_ShowPrice
+ */
+
+declare(strict_types=1);
+
+namespace Mailcode;
+
+/**
+ * Mailcode command: show a date variable value.
+ *
+ * @package Mailcode
+ * @subpackage Commands
+ * @author Olaf Böcker <olaf.boecker@ionos.com>
+ */
+class Mailcode_Commands_Command_ShowPrice extends Mailcode_Commands_ShowBase
+    implements
+    CurrencyNameInterface
+{
+    public const VALIDATION_CODE_1 = 163401;
+
+    use CurrencyNameTrait;
+
+    /**
+     * @var Mailcode_Parser_Statement_Tokenizer_Token_Keyword|NULL
+     */
+    private ?Mailcode_Parser_Statement_Tokenizer_Token_Keyword $absoluteKeyword = null;
+
+    /**
+     * @var Mailcode_Number_LocalCurrency
+     */
+    private Mailcode_Number_LocalCurrency $localCurrency;
+
+    public function getName(): string
+    {
+        return 'showprice';
+    }
+
+    public function getLabel(): string
+    {
+        return t('Show price variable');
+    }
+
+    protected function getValidations(): array
+    {
+        return array(
+            Mailcode_Interfaces_Commands_Validation_Variable::VALIDATION_NAME_VARIABLE,
+            'absolute'
+        );
+    }
+
+    protected function validateSyntax_absolute(): void
+    {
+        $keywords = $this->requireParams()
+            ->getInfo()
+            ->getKeywords();
+
+        foreach ($keywords as $keyword) {
+            if ($keyword->getKeyword() === Mailcode_Commands_Keywords::TYPE_ABSOLUTE) {
+                $this->absoluteKeyword = $keyword;
+                break;
+            }
+        }
+    }
+
+    public function isAbsolute(): bool
+    {
+        return isset($this->absoluteKeyword);
+    }
+
+    public function setAbsolute(bool $absolute): Mailcode_Commands_Command_ShowPrice
+    {
+        if ($absolute === false && isset($this->absoluteKeyword)) {
+            $this->requireParams()->getInfo()->removeKeyword($this->absoluteKeyword->getKeyword());
+            $this->absoluteKeyword = null;
+        }
+
+        if ($absolute === true && !isset($this->absoluteKeyword)) {
+            $this->requireParams()
+                ->getInfo()
+                ->addKeyword(Mailcode_Commands_Keywords::TYPE_ABSOLUTE);
+
+            $this->validateSyntax_absolute();
+        }
+
+        return $this;
+    }
+
+    public function getLocalCurrency(): Mailcode_Number_LocalCurrency
+    {
+        if (!isset($this->localCurrency)) {
+            $this->localCurrency = Mailcode_Number_LocalCurrency::defaultInstance();
+        }
+        return $this->localCurrency;
+    }
+
+    public function setLocalCurrency(Mailcode_Number_LocalCurrency $localCurrency): Mailcode_Commands_Command_ShowPrice
+    {
+        $this->localCurrency = $localCurrency;
+        return $this;
+    }
+}
+

--- a/src/Mailcode/Commands/Command/ShowPrice.php
+++ b/src/Mailcode/Commands/Command/ShowPrice.php
@@ -20,10 +20,10 @@ namespace Mailcode;
  */
 class Mailcode_Commands_Command_ShowPrice extends Mailcode_Commands_ShowBase
     implements
-    CurrencyNameInterface
+    RegionInterface, CurrencyInterface, CurrencyNameInterface
 {
-    public const VALIDATION_CODE_1 = 163401;
-
+    use RegionTrait;
+    use CurrencyTrait;
     use CurrencyNameTrait;
 
     /**
@@ -50,7 +50,10 @@ class Mailcode_Commands_Command_ShowPrice extends Mailcode_Commands_ShowBase
     {
         return array(
             Mailcode_Interfaces_Commands_Validation_Variable::VALIDATION_NAME_VARIABLE,
-            'absolute'
+            'absolute',
+            'check_currency_exclusive',
+            'check_currency',
+            'check_region'
         );
     }
 
@@ -65,6 +68,26 @@ class Mailcode_Commands_Command_ShowPrice extends Mailcode_Commands_ShowBase
                 $this->absoluteKeyword = $keyword;
                 break;
             }
+        }
+    }
+
+    protected function validateSyntax_check_currency_exclusive(): void
+    {
+        $hasCurrencyNameKeyword = $this
+            ->requireParams()
+            ->getInfo()
+            ->hasKeyword(Mailcode_Commands_Keywords::TYPE_CURRENCY_NAME);
+
+        $hasCurrencyParameter = $this
+            ->requireParams()
+            ->getInfo()
+            ->getTokenByParamName(CurrencyInterface::CURRENCY_PARAMETER_NAME);
+
+        if ($hasCurrencyParameter && $hasCurrencyNameKeyword) {
+            $this->validationResult->makeError(
+                t("Can not use both 'currency-name' and 'currency'"),
+                CurrencyInterface::VALIDATION_CURRENCY_EXCLUSIVE
+            );
         }
     }
 

--- a/src/Mailcode/Commands/Command/ShowPrice.php
+++ b/src/Mailcode/Commands/Command/ShowPrice.php
@@ -11,8 +11,11 @@ declare(strict_types=1);
 
 namespace Mailcode;
 
+use Mailcode\Interfaces\Commands\Validation\AbsoluteKeywordInterface;
+use Mailcode\Traits\Commands\Validation\AbsoluteKeywordTrait;
+
 /**
- * Mailcode command: show a date variable value.
+ * Mailcode command: Display a variable containing a price with currency.
  *
  * @package Mailcode
  * @subpackage Commands
@@ -20,16 +23,15 @@ namespace Mailcode;
  */
 class Mailcode_Commands_Command_ShowPrice extends Mailcode_Commands_ShowBase
     implements
-    RegionInterface, CurrencyInterface, CurrencyNameInterface
+    RegionInterface,
+    CurrencyInterface,
+    CurrencyNameInterface,
+    AbsoluteKeywordInterface
 {
     use RegionTrait;
     use CurrencyTrait;
     use CurrencyNameTrait;
-
-    /**
-     * @var Mailcode_Parser_Statement_Tokenizer_Token_Keyword|NULL
-     */
-    private ?Mailcode_Parser_Statement_Tokenizer_Token_Keyword $absoluteKeyword = null;
+    use AbsoluteKeywordTrait;
 
     /**
      * @var Mailcode_Number_LocalCurrency
@@ -50,25 +52,11 @@ class Mailcode_Commands_Command_ShowPrice extends Mailcode_Commands_ShowBase
     {
         return array(
             Mailcode_Interfaces_Commands_Validation_Variable::VALIDATION_NAME_VARIABLE,
-            'absolute',
+            AbsoluteKeywordInterface::VALIDATION_NAME,
             'check_currency_exclusive',
             'check_currency',
             'check_region'
         );
-    }
-
-    protected function validateSyntax_absolute(): void
-    {
-        $keywords = $this->requireParams()
-            ->getInfo()
-            ->getKeywords();
-
-        foreach ($keywords as $keyword) {
-            if ($keyword->getKeyword() === Mailcode_Commands_Keywords::TYPE_ABSOLUTE) {
-                $this->absoluteKeyword = $keyword;
-                break;
-            }
-        }
     }
 
     protected function validateSyntax_check_currency_exclusive(): void
@@ -89,29 +77,6 @@ class Mailcode_Commands_Command_ShowPrice extends Mailcode_Commands_ShowBase
                 CurrencyInterface::VALIDATION_CURRENCY_EXCLUSIVE
             );
         }
-    }
-
-    public function isAbsolute(): bool
-    {
-        return isset($this->absoluteKeyword);
-    }
-
-    public function setAbsolute(bool $absolute): Mailcode_Commands_Command_ShowPrice
-    {
-        if ($absolute === false && isset($this->absoluteKeyword)) {
-            $this->requireParams()->getInfo()->removeKeyword($this->absoluteKeyword->getKeyword());
-            $this->absoluteKeyword = null;
-        }
-
-        if ($absolute === true && !isset($this->absoluteKeyword)) {
-            $this->requireParams()
-                ->getInfo()
-                ->addKeyword(Mailcode_Commands_Keywords::TYPE_ABSOLUTE);
-
-            $this->validateSyntax_absolute();
-        }
-
-        return $this;
     }
 
     public function getLocalCurrency(): Mailcode_Number_LocalCurrency

--- a/src/Mailcode/Commands/Command/ShowSnippet.php
+++ b/src/Mailcode/Commands/Command/ShowSnippet.php
@@ -18,29 +18,32 @@ namespace Mailcode;
  * @subpackage Commands
  * @author Sebastian Mordziol <s.mordziol@mistralys.eu>
  */
-class Mailcode_Commands_Command_ShowSnippet extends Mailcode_Commands_ShowBase implements Mailcode_Interfaces_Commands_Validation_NoHTML
+class Mailcode_Commands_Command_ShowSnippet
+    extends Mailcode_Commands_ShowBase
+    implements
+    Mailcode_Interfaces_Commands_Validation_NoHTML
 {
     use Mailcode_Traits_Commands_Validation_NoHTML;
 
-    public function getName() : string
+    public function getName(): string
     {
         return 'showsnippet';
     }
-    
-    public function getLabel() : string
+
+    public function getLabel(): string
     {
         return t('Show text snippet');
     }
-    
-    protected function getValidations() : array
+
+    protected function getValidations(): array
     {
         return array(
             Mailcode_Interfaces_Commands_Validation_Variable::VALIDATION_NAME_VARIABLE,
             Mailcode_Interfaces_Commands_Validation_NoHTML::VALIDATION_NAME_NOHTML
         );
     }
-    
-    public function generatesContent() : bool
+
+    public function generatesContent(): bool
     {
         return true;
     }

--- a/src/Mailcode/Commands/Keywords.php
+++ b/src/Mailcode/Commands/Keywords.php
@@ -32,6 +32,7 @@ class Mailcode_Commands_Keywords
     public const TYPE_NOHTML = 'nohtml:';
     public const TYPE_ABSOLUTE = 'absolute:';
     public const TYPE_NO_TRACKING = 'no-tracking:';
+    public const TYPE_CURRENCY_NAME = 'currency-name:';
 
     /**
      * @return string[]
@@ -49,7 +50,8 @@ class Mailcode_Commands_Keywords
             self::TYPE_IDN_DECODE,
             self::TYPE_NOHTML,
             self::TYPE_ABSOLUTE,
-            self::TYPE_NO_TRACKING
+            self::TYPE_NO_TRACKING,
+            self::TYPE_CURRENCY_NAME
         );
     }
 }

--- a/src/Mailcode/Factory/CommandSets/Set/Show.php
+++ b/src/Mailcode/Factory/CommandSets/Set/Show.php
@@ -61,9 +61,11 @@ class Mailcode_Factory_CommandSets_Set_Show extends Mailcode_Factory_CommandSets
         return (new Number())->create($variableName, $formatString, $absolute);
     }
 
-    public function price(string $variableName, bool $absolute = false, bool $withCurrencyName = true): Mailcode_Commands_Command_ShowPrice
+    public function price(string $variableName, bool $absolute = false, bool $withCurrencyName = false,
+                          string $currencyString = null, string $currencyVariable = null,
+                          string $regionString = null, string $regionVariable = null): Mailcode_Commands_Command_ShowPrice
     {
-        return (new Price())->create($variableName, $absolute, $withCurrencyName);
+        return (new Price())->create($variableName, $absolute, $withCurrencyName, $currencyString, $currencyVariable, $regionString, $regionVariable);
     }
 
     /**

--- a/src/Mailcode/Factory/CommandSets/Set/Show.php
+++ b/src/Mailcode/Factory/CommandSets/Set/Show.php
@@ -15,6 +15,7 @@ use Mailcode\Factory\CommandSets\Set\Show\Date;
 use Mailcode\Factory\CommandSets\Set\Show\Encoded;
 use Mailcode\Factory\CommandSets\Set\Show\Number;
 use Mailcode\Factory\CommandSets\Set\Show\Phone;
+use Mailcode\Factory\CommandSets\Set\Show\Price;
 use Mailcode\Factory\CommandSets\Set\Show\Snippet;
 use Mailcode\Factory\CommandSets\Set\Show\URL;
 
@@ -58,6 +59,11 @@ class Mailcode_Factory_CommandSets_Set_Show extends Mailcode_Factory_CommandSets
     public function number(string $variableName, string $formatString = "", bool $absolute = false): Mailcode_Commands_Command_ShowNumber
     {
         return (new Number())->create($variableName, $formatString, $absolute);
+    }
+
+    public function price(string $variableName, bool $absolute = false, bool $withCurrencyName = true): Mailcode_Commands_Command_ShowPrice
+    {
+        return (new Price())->create($variableName, $absolute, $withCurrencyName);
     }
 
     /**

--- a/src/Mailcode/Factory/CommandSets/Set/Show/Price.php
+++ b/src/Mailcode/Factory/CommandSets/Set/Show/Price.php
@@ -11,8 +11,11 @@ declare(strict_types=1);
 
 namespace Mailcode\Factory\CommandSets\Set\Show;
 
+use Mailcode\CurrencyInterface;
 use Mailcode\Mailcode_Commands_Command_ShowPrice;
+use Mailcode\Mailcode_Commands_Keywords;
 use Mailcode\Mailcode_Factory_CommandSets_Set;
+use Mailcode\RegionInterface;
 
 /**
  * Factory class for the `shownumber` command.
@@ -23,10 +26,15 @@ use Mailcode\Mailcode_Factory_CommandSets_Set;
  */
 class Price extends Mailcode_Factory_CommandSets_Set
 {
-    public function create(string $variableName, bool $absolute = false, bool $withCurrencyName = true): Mailcode_Commands_Command_ShowPrice
+    public function create(string $variableName, bool $absolute = false, bool $withCurrencyName = true,
+                           string $currencyString = null, string $currencyVariable = null,
+                           string $regionString = null, string $regionVariable = null): Mailcode_Commands_Command_ShowPrice
     {
         $variableName = $this->instantiator->filterVariableName($variableName);
-        $paramsString = $this->compilePriceParams($absolute, $withCurrencyName);
+
+        $paramsString = $this->compilePriceParams($absolute, $withCurrencyName,
+            $currencyString, $currencyVariable,
+            $regionString, $regionVariable);
 
         $cmd = $this->commands->createCommand(
             'ShowPrice',
@@ -48,16 +56,40 @@ class Price extends Mailcode_Factory_CommandSets_Set
         throw $this->instantiator->exceptionUnexpectedType('ShowPrice', $cmd);
     }
 
-    private function compilePriceParams(bool $absolute = false, bool $withCurrencyName = true): string
+    private function compilePriceParams(bool   $absolute = false, bool $withCurrencyName = true,
+                                        string $currencyString = null, string $currencyVariable = null,
+                                        string $regionString = null, string $regionVariable = null): string
     {
         $params = array();
 
         if ($absolute) {
-            $params[] = ' absolute:';
+            $params[] = ' ' . Mailcode_Commands_Keywords::TYPE_ABSOLUTE;
         }
 
-        if ($withCurrencyName) {
-            $params[] = ' currency-name:';
+        if ($currencyString) {
+            $params[] = sprintf(
+                ' ' . CurrencyInterface::CURRENCY_PARAMETER_NAME . '=%s',
+                $this->quoteString($currencyString)
+            );
+        } else if ($currencyVariable) {
+            $params[] = sprintf(
+                ' ' . CurrencyInterface::CURRENCY_PARAMETER_NAME . '=%s',
+                $currencyVariable
+            );
+        } else if ($withCurrencyName) {
+            $params[] = ' ' . Mailcode_Commands_Keywords::TYPE_CURRENCY_NAME;
+        }
+
+        if ($regionString) {
+            $params[] = sprintf(
+                ' ' . RegionInterface::REGION_PARAMETER_NAME . '=%s',
+                $this->quoteString($regionString)
+            );
+        } else if ($regionVariable) {
+            $params[] = sprintf(
+                ' ' . RegionInterface::REGION_PARAMETER_NAME . '=%s',
+                $regionVariable
+            );
         }
 
         if (!empty($params)) {

--- a/src/Mailcode/Factory/CommandSets/Set/Show/Price.php
+++ b/src/Mailcode/Factory/CommandSets/Set/Show/Price.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * File containing the class {@see \Mailcode\Factory\CommandSets\Set\Show\Price}.
+ *
+ * @package Mailcode
+ * @subpackage Factory
+ * @see \Mailcode\Factory\CommandSets\Set\Show\Price
+ */
+
+declare(strict_types=1);
+
+namespace Mailcode\Factory\CommandSets\Set\Show;
+
+use Mailcode\Mailcode_Commands_Command_ShowPrice;
+use Mailcode\Mailcode_Factory_CommandSets_Set;
+
+/**
+ * Factory class for the `shownumber` command.
+ *
+ * @package Mailcode
+ * @subpackage Factory
+ * @author Olaf Böcker <olaf.boecker@ionos.com>
+ */
+class Price extends Mailcode_Factory_CommandSets_Set
+{
+    public function create(string $variableName, bool $absolute = false, bool $withCurrencyName = true): Mailcode_Commands_Command_ShowPrice
+    {
+        $variableName = $this->instantiator->filterVariableName($variableName);
+        $paramsString = $this->compilePriceParams($absolute, $withCurrencyName);
+
+        $cmd = $this->commands->createCommand(
+            'ShowPrice',
+            '',
+            $variableName . $paramsString,
+            sprintf(
+                '{showprice: %s%s}',
+                $variableName,
+                $paramsString
+            )
+        );
+
+        $this->instantiator->checkCommand($cmd);
+
+        if ($cmd instanceof Mailcode_Commands_Command_ShowPrice) {
+            return $cmd;
+        }
+
+        throw $this->instantiator->exceptionUnexpectedType('ShowPrice', $cmd);
+    }
+
+    private function compilePriceParams(bool $absolute = false, bool $withCurrencyName = true): string
+    {
+        $params = array();
+
+        if ($absolute) {
+            $params[] = ' absolute:';
+        }
+
+        if ($withCurrencyName) {
+            $params[] = ' currency-name:';
+        }
+
+        if (!empty($params)) {
+            return ' ' . implode(' ', $params);
+        }
+
+        return '';
+    }
+}

--- a/src/Mailcode/Interfaces/Commands/Validation/AbsoluteKeywordInterface.php
+++ b/src/Mailcode/Interfaces/Commands/Validation/AbsoluteKeywordInterface.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @package Mailcode
+ * @subpackage Validation
+ */
+
+declare(strict_types=1);
+
+namespace Mailcode\Interfaces\Commands\Validation;
+
+use Mailcode\Mailcode_Interfaces_Commands_Command;
+use Mailcode\Traits\Commands\Validation\AbsoluteKeywordTrait;
+
+/**
+ * Interface for the trait {@see AbsoluteKeywordTrait}.
+ *
+ * @package Mailcode
+ * @subpackage Validation
+ * @author Sebastian Mordziol <s.mordziol@mistralys.eu>
+ *
+ * @see AbsoluteKeywordTrait
+ */
+interface AbsoluteKeywordInterface extends Mailcode_Interfaces_Commands_Command
+{
+    public const VALIDATION_NAME = 'absolute';
+
+    /**
+     * Whether the target number is set to be displayed as an absolute value.
+     * @return bool
+     */
+    public function isAbsolute(): bool;
+
+    /**
+     * Sets whether the target number should be displayed as an absolute value.
+     * @param bool $absolute
+     * @return $this
+     */
+    public function setAbsolute(bool $absolute): self;
+}

--- a/src/Mailcode/Interfaces/Commands/Validation/CurrencyInterface.php
+++ b/src/Mailcode/Interfaces/Commands/Validation/CurrencyInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * File containing the interface {@see \Mailcode\Interfaces\Commands\Validation\CurrencyInterface}.
+ *
+ * @package Mailcode
+ * @subpackage Validation
+ * @see \Mailcode\Interfaces\Commands\Validation\CurrencyInterface
+ */
+
+declare(strict_types=1);
+
+namespace Mailcode;
+
+/**
+ * @package Mailcode
+ * @subpackage Validation
+ * @author Olaf Böcker <olaf.boecker@ionos.com>
+ *
+ * @see CurrencyTrait
+ */
+interface CurrencyInterface extends Mailcode_Interfaces_Commands_Command
+{
+    public const CURRENCY_PARAMETER_NAME = 'currency';
+
+    public const VALIDATION_CURRENCY_WRONG_TYPE = 166201;
+    public const VALIDATION_CURRENCY_EXCLUSIVE = 166202;
+
+    public function isCurrencyPresent(): bool;
+
+    public function getCurrencyToken(): ?Mailcode_Parser_Statement_Tokenizer_Token;
+}

--- a/src/Mailcode/Interfaces/Commands/Validation/CurrencyNameInterface.php
+++ b/src/Mailcode/Interfaces/Commands/Validation/CurrencyNameInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * File containing the interface {@see \Mailcode\Interfaces\Commands\Validation\CurrencyNameInterface}.
+ *
+ * @package Mailcode
+ * @subpackage Validation
+ * @see \Mailcode\Interfaces\Commands\Validation\CurrencyNameInterface
+ */
+
+declare(strict_types=1);
+
+namespace Mailcode;
+
+/**
+ * @package Mailcode
+ * @subpackage Validation
+ * @author Olaf Böcker <olaf.boecker@ionos.com>
+ *
+ * @see CurrencyNameTrait
+ */
+interface CurrencyNameInterface extends Mailcode_Interfaces_Commands_Command
+{
+    public function isCurrencyNameEnabled(): bool;
+
+    public function getCurrencyNameToken(): ?Mailcode_Parser_Statement_Tokenizer_Token_Keyword;
+
+    public function setCurrencyNameEnabled(bool $enabled): self;
+}

--- a/src/Mailcode/Interfaces/Commands/Validation/DecryptInterface.php
+++ b/src/Mailcode/Interfaces/Commands/Validation/DecryptInterface.php
@@ -40,8 +40,9 @@ interface DecryptInterface extends Mailcode_Interfaces_Commands_Command
      */
     public function getDecryptionKeyToken(): ?Mailcode_Parser_Statement_Tokenizer_Token_StringLiteral;
 
-    public function enableDecryption(string $keyName=DecryptInterface::DEFAULT_DECRYPTION_KEY_NAME) : self;
+    public function enableDecryption(string $keyName = DecryptInterface::DEFAULT_DECRYPTION_KEY_NAME): self;
 
-    public function disableDecryption() : self;
-    public function isDecryptionEnabled() : bool;
+    public function disableDecryption(): self;
+
+    public function isDecryptionEnabled(): bool;
 }

--- a/src/Mailcode/Interfaces/Commands/Validation/RegionInterface.php
+++ b/src/Mailcode/Interfaces/Commands/Validation/RegionInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * File containing the interface {@see \Mailcode\Interfaces\Commands\Validation\RegionInterface}.
+ *
+ * @package Mailcode
+ * @subpackage Validation
+ * @see \Mailcode\Interfaces\Commands\Validation\RegionInterface
+ */
+
+declare(strict_types=1);
+
+namespace Mailcode;
+
+/**
+ * @package Mailcode
+ * @subpackage Validation
+ * @author Olaf Böcker <olaf.boecker@ionos.com>
+ *
+ * @see RegionTrait
+ */
+interface RegionInterface extends Mailcode_Interfaces_Commands_Command
+{
+    public const REGION_PARAMETER_NAME = 'region';
+
+    public const VALIDATION_REGION_WRONG_TYPE = 166101;
+
+    public function isRegionPresent(): bool;
+
+    public function getRegionToken(): ?Mailcode_Parser_Statement_Tokenizer_Token;
+}

--- a/src/Mailcode/Number/LocalCurrency.php
+++ b/src/Mailcode/Number/LocalCurrency.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailcode;
+
+use AppUtils\OperationResult;
+
+class Mailcode_Number_LocalCurrency extends OperationResult
+{
+    public const DEFAULT_COUNTRY = "US";
+    public const DEFAULT_CURRENCY_NAME = "USD";
+    public const DEFAULT_CURRENCY_SYMBOL = "$";
+    public const DEFAULT_UNIT_SEPARATOR = " ";
+    public const DEFAULT_FORMAT = "1,000.00";
+
+    private string $country;
+    private string $currencyName;
+    private string $currencySymbol;
+    private string $unitSeparator;
+    private string $formatString;
+
+    private static ?Mailcode_Number_LocalCurrency $instance = null;
+
+    /**
+     * @param string $country
+     * @param string $currencyName
+     * @param string $currencySymbol
+     * @param string $unitSeparator
+     * @param string $formatString
+     */
+    public function __construct(string $country, string $currencyName, string $currencySymbol, string $unitSeparator, string $formatString)
+    {
+        $this->country = $country;
+        $this->currencyName = $currencyName;
+        $this->currencySymbol = $currencySymbol;
+        $this->unitSeparator = $unitSeparator;
+        $this->formatString = $formatString;
+    }
+
+    public function getCountry(): string
+    {
+        return $this->country;
+    }
+
+    public function getCurrencyName(): string
+    {
+        return $this->currencyName;
+    }
+
+    public function getCurrencySymbol(): string
+    {
+        return $this->currencySymbol;
+    }
+
+    public function getUnitSeparator(): string
+    {
+        return $this->unitSeparator;
+    }
+
+    public function getFormatString(): string
+    {
+        return $this->formatString;
+    }
+
+    public function getFormatInfo(): Mailcode_Number_Info
+    {
+        return new Mailcode_Number_Info($this->formatString);
+    }
+
+    public static function defaultInstance(): Mailcode_Number_LocalCurrency
+    {
+        if (!isset(self::$instance)) {
+            self::$instance = new self(
+                self::DEFAULT_COUNTRY,
+                self::DEFAULT_CURRENCY_NAME,
+                self::DEFAULT_CURRENCY_SYMBOL,
+                self::DEFAULT_UNIT_SEPARATOR,
+                self::DEFAULT_FORMAT
+            );
+        }
+        return self::$instance;
+    }
+}

--- a/src/Mailcode/Number/LocalCurrency.php
+++ b/src/Mailcode/Number/LocalCurrency.php
@@ -20,6 +20,9 @@ class Mailcode_Number_LocalCurrency extends OperationResult
     private string $unitSeparator;
     private string $formatString;
 
+    private ?Mailcode_Parser_Statement_Tokenizer_Token_Variable $currency = null;
+    private ?Mailcode_Parser_Statement_Tokenizer_Token_Variable $region = null;
+
     private static ?Mailcode_Number_LocalCurrency $instance = null;
 
     /**
@@ -28,14 +31,25 @@ class Mailcode_Number_LocalCurrency extends OperationResult
      * @param string $currencySymbol
      * @param string $unitSeparator
      * @param string $formatString
+     * @param ?Mailcode_Parser_Statement_Tokenizer_Token $currency
+     * @param ?Mailcode_Parser_Statement_Tokenizer_Token $region
      */
-    public function __construct(string $country, string $currencyName, string $currencySymbol, string $unitSeparator, string $formatString)
+    public function __construct(string                                     $country,
+                                string                                     $currencyName,
+                                string                                     $currencySymbol,
+                                string                                     $unitSeparator,
+                                string                                     $formatString,
+                                ?Mailcode_Parser_Statement_Tokenizer_Token $currency = null,
+                                ?Mailcode_Parser_Statement_Tokenizer_Token $region = null)
     {
         $this->country = $country;
         $this->currencyName = $currencyName;
         $this->currencySymbol = $currencySymbol;
         $this->unitSeparator = $unitSeparator;
         $this->formatString = $formatString;
+
+        $this->currency = $currency;
+        $this->region = $region;
     }
 
     public function getCountry(): string
@@ -61,6 +75,42 @@ class Mailcode_Number_LocalCurrency extends OperationResult
     public function getFormatString(): string
     {
         return $this->formatString;
+    }
+
+    public function getRegion(): ?Mailcode_Parser_Statement_Tokenizer_Token
+    {
+        return $this->region;
+    }
+
+    public function getCurrency(): ?Mailcode_Parser_Statement_Tokenizer_Token
+    {
+        return $this->currency;
+    }
+
+    public function withRegion(?Mailcode_Parser_Statement_Tokenizer_Token $region = null): Mailcode_Number_LocalCurrency
+    {
+        return new Mailcode_Number_LocalCurrency(
+            $this->country,
+            $this->currencyName,
+            $this->currencySymbol,
+            $this->unitSeparator,
+            $this->formatString,
+            $this->currency,
+            $region
+        );
+    }
+
+    public function withCurrency(?Mailcode_Parser_Statement_Tokenizer_Token $currency = null): Mailcode_Number_LocalCurrency
+    {
+        return new Mailcode_Number_LocalCurrency(
+            $this->country,
+            $this->currencyName,
+            $this->currencySymbol,
+            $this->unitSeparator,
+            $this->formatString,
+            $currency,
+            $this->region
+        );
     }
 
     public function getFormatInfo(): Mailcode_Number_Info

--- a/src/Mailcode/Traits/Commands/Validation/AbsoluteKeywordTrait.php
+++ b/src/Mailcode/Traits/Commands/Validation/AbsoluteKeywordTrait.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @package Mailcode
+ * @subpackage Validation
+ */
+
+declare(strict_types=1);
+
+namespace Mailcode\Traits\Commands\Validation;
+
+use Mailcode\Interfaces\Commands\Validation\AbsoluteKeywordInterface;
+use Mailcode\Mailcode_Commands_Keywords;
+use Mailcode\Mailcode_Parser_Statement_Tokenizer_Token_Keyword;
+
+/**
+ * Command validation drop-in: checks for the presence
+ * of the `absolute:` keyword in the command statement,
+ * and sets the absolute number flag accordingly.
+ *
+ * @package Mailcode
+ * @subpackage Validation
+ * @author Sebastian Mordziol <s.mordziol@mistralys.eu>
+ *
+ * @see AbsoluteKeywordInterface
+ */
+trait AbsoluteKeywordTrait
+{
+    /**
+     * @var Mailcode_Parser_Statement_Tokenizer_Token_Keyword|NULL
+     */
+    private ?Mailcode_Parser_Statement_Tokenizer_Token_Keyword $absoluteKeyword = null;
+
+    protected function validateSyntax_absolute(): void
+    {
+        $keywords = $this->requireParams()
+            ->getInfo()
+            ->getKeywords();
+
+        foreach ($keywords as $keyword) {
+            if ($keyword->getKeyword() === Mailcode_Commands_Keywords::TYPE_ABSOLUTE) {
+                $this->absoluteKeyword = $keyword;
+                break;
+            }
+        }
+    }
+
+    public function isAbsolute(): bool
+    {
+        return isset($this->absoluteKeyword);
+    }
+
+    /**
+     * @inheritdoc
+     * @return $this
+     */
+    public function setAbsolute(bool $absolute): self
+    {
+        if ($absolute === false && isset($this->absoluteKeyword)) {
+            $this->requireParams()->getInfo()->removeKeyword($this->absoluteKeyword->getKeyword());
+            $this->absoluteKeyword = null;
+        }
+
+        if ($absolute === true && !isset($this->absoluteKeyword)) {
+            $this->requireParams()
+                ->getInfo()
+                ->addKeyword(Mailcode_Commands_Keywords::TYPE_ABSOLUTE);
+
+            $this->validateSyntax_absolute();
+        }
+
+        return $this;
+    }
+}

--- a/src/Mailcode/Traits/Commands/Validation/CurrencyNameTrait.php
+++ b/src/Mailcode/Traits/Commands/Validation/CurrencyNameTrait.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * File containing the {@see \Mailcode\Traits\Commands\Validation\CurrencyNameTrait} trait.
+ *
+ * @see \Mailcode\Traits\Commands\Validation\CurrencyNameTrait
+ * @subpackage Validation
+ * @package Mailcode
+ */
+
+declare(strict_types=1);
+
+namespace Mailcode;
+
+use Mailcode\Interfaces\Commands\Validation\NoTrackingInterface;
+
+/**
+ * Command validation drop-in: checks for the presence
+ * of the `currency-name:` keyword in the command statement,
+ * and sets the currency name enabled flag accordingly.
+ *
+ * @package Mailcode
+ * @subpackage Validation
+ * @author Olaf Böcker <olaf.boecker@ionos.com>
+ *
+ * @see NoTrackingInterface
+ */
+trait CurrencyNameTrait
+{
+    public function isCurrencyNameEnabled(): bool
+    {
+        return $this->requireParams()
+            ->getInfo()
+            ->hasKeyword(Mailcode_Commands_Keywords::TYPE_CURRENCY_NAME);
+    }
+
+    /**
+     * @param bool $enabled
+     * @return $this
+     * @throws Mailcode_Exception
+     */
+    public function setCurrencyNameEnabled(bool $enabled): self
+    {
+        $this->requireParams()
+            ->getInfo()
+            ->setKeywordEnabled(Mailcode_Commands_Keywords::TYPE_CURRENCY_NAME, $enabled);
+
+        return $this;
+    }
+
+    public function getCurrencyNameToken(): ?Mailcode_Parser_Statement_Tokenizer_Token_Keyword
+    {
+        return $this->requireParams()
+            ->getInfo()
+            ->getKeywordsCollection()
+            ->getByName(Mailcode_Commands_Keywords::TYPE_CURRENCY_NAME);
+    }
+}

--- a/src/Mailcode/Traits/Commands/Validation/CurrencyNameTrait.php
+++ b/src/Mailcode/Traits/Commands/Validation/CurrencyNameTrait.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
 
 namespace Mailcode;
 
-use Mailcode\Interfaces\Commands\Validation\NoTrackingInterface;
-
 /**
  * Command validation drop-in: checks for the presence
  * of the `currency-name:` keyword in the command statement,
@@ -22,10 +20,13 @@ use Mailcode\Interfaces\Commands\Validation\NoTrackingInterface;
  * @subpackage Validation
  * @author Olaf Böcker <olaf.boecker@ionos.com>
  *
- * @see NoTrackingInterface
+ * @see CurrencyNameInterface
  */
 trait CurrencyNameTrait
 {
+    /**
+     * @throws Mailcode_Exception
+     */
     public function isCurrencyNameEnabled(): bool
     {
         return $this->requireParams()
@@ -47,6 +48,9 @@ trait CurrencyNameTrait
         return $this;
     }
 
+    /**
+     * @throws Mailcode_Exception
+     */
     public function getCurrencyNameToken(): ?Mailcode_Parser_Statement_Tokenizer_Token_Keyword
     {
         return $this->requireParams()

--- a/src/Mailcode/Traits/Commands/Validation/CurrencyTrait.php
+++ b/src/Mailcode/Traits/Commands/Validation/CurrencyTrait.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * File containing the trait {@see \Mailcode\Traits\Commands\Validation\CurrencyTrait}.
+ *
+ * @package Mailcode
+ * @subpackage Validation
+ * @see \Mailcode\Traits\Commands\Validation\CurrencyTrait
+ */
+
+declare(strict_types=1);
+
+namespace Mailcode;
+
+/**
+ * @package Mailcode
+ * @subpackage Validation
+ * @author Olaf Böcker <olaf.boecker@ionos.com>
+ *
+ * @see CurrencyInterface
+ */
+trait CurrencyTrait
+{
+    private ?Mailcode_Parser_Statement_Tokenizer_Token $currency = null;
+
+    /**
+     * @throws Mailcode_Exception
+     */
+    protected function validateSyntax_check_currency(): void
+    {
+        $token = $this
+            ->requireParams()
+            ->getInfo()
+            ->getTokenByParamName(CurrencyInterface::CURRENCY_PARAMETER_NAME);
+
+        if ($token === null) {
+            return;
+        }
+
+        if (!$token instanceof Mailcode_Parser_Statement_Tokenizer_Token_Variable &&
+            !$token instanceof Mailcode_Parser_Statement_Tokenizer_Token_StringLiteral) {
+            $this->validationResult->makeError(
+                t('Invalid currency token:') . ' ' . t('Expected a variable or a string.'),
+                CurrencyInterface::VALIDATION_CURRENCY_WRONG_TYPE
+            );
+            return;
+        }
+
+        $this->currency = $token;
+    }
+
+    public function isCurrencyPresent(): bool
+    {
+        return $this->getCurrencyToken() !== null;
+    }
+
+    public function getCurrencyToken(): ?Mailcode_Parser_Statement_Tokenizer_Token
+    {
+        return $this->currency;
+    }
+}

--- a/src/Mailcode/Traits/Commands/Validation/RegionTrait.php
+++ b/src/Mailcode/Traits/Commands/Validation/RegionTrait.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * File containing the trait {@see \Mailcode\Traits\Commands\Validation\RegionTrait}.
+ *
+ * @package Mailcode
+ * @subpackage Validation
+ * @see \Mailcode\Traits\Commands\Validation\RegionTrait
+ */
+
+declare(strict_types=1);
+
+namespace Mailcode;
+
+/**
+ * @package Mailcode
+ * @subpackage Validation
+ * @author Olaf Böcker <olaf.boecker@ionos.com>
+ *
+ * @see RegionInterface
+ */
+trait RegionTrait
+{
+    private ?Mailcode_Parser_Statement_Tokenizer_Token $region = null;
+
+    /**
+     * @throws Mailcode_Exception
+     */
+    protected function validateSyntax_check_region(): void
+    {
+        $token = $this
+            ->requireParams()
+            ->getInfo()
+            ->getTokenByParamName(RegionInterface::REGION_PARAMETER_NAME);
+
+        if ($token === null) {
+            return;
+        }
+
+        if (!$token instanceof Mailcode_Parser_Statement_Tokenizer_Token_Variable &&
+            !$token instanceof Mailcode_Parser_Statement_Tokenizer_Token_StringLiteral) {
+            $this->validationResult->makeError(
+                t('Invalid region token:') . ' ' . t('Expected a variable or a string.'),
+                RegionInterface::VALIDATION_REGION_WRONG_TYPE
+            );
+            return;
+        }
+
+        $this->region = $token;
+    }
+
+    public function isRegionPresent(): bool
+    {
+        return $this->getRegionToken() !== null;
+    }
+
+    public function getRegionToken(): ?Mailcode_Parser_Statement_Tokenizer_Token
+    {
+        return $this->region;
+    }
+}

--- a/src/Mailcode/Translator/Command/ShowPrice.php
+++ b/src/Mailcode/Translator/Command/ShowPrice.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * File containing the {@see \Mailcode\Mailcode_Translator_Command_ShowPrice} interface.
+ *
+ * @package Mailcode
+ * @subpackage Translator
+ * @see \Mailcode\Mailcode_Translator_Command_ShowPrice
+ */
+
+declare(strict_types=1);
+
+namespace Mailcode;
+
+/**
+ * Interface for translators of the "ShowPrice" command.
+ *
+ * @package Mailcode
+ * @subpackage Translator
+ * @author Olaf Böcker <olaf.boecker@ionos.com>
+ */
+interface Mailcode_Translator_Command_ShowPrice
+{
+    public function translate(Mailcode_Commands_Command_ShowPrice $command): string;
+}

--- a/src/Mailcode/Translator/Syntax/ApacheVelocity.php
+++ b/src/Mailcode/Translator/Syntax/ApacheVelocity.php
@@ -15,6 +15,7 @@ use Mailcode\Interfaces\Commands\EncodableInterface;
 use Mailcode\Mailcode_Commands_Command;
 use Mailcode\Mailcode_Commands_Keywords;
 use Mailcode\Mailcode_Number_Info;
+use Mailcode\Mailcode_Number_LocalCurrency;
 use Mailcode\Translator\BaseCommandTranslation;
 use function Mailcode\dollarize;
 
@@ -121,6 +122,31 @@ abstract class ApacheVelocity extends BaseCommandTranslation
         return sprintf(
             '$numeric.toNumber(%s)',
             dollarize($varName)
+        );
+    }
+
+    public function renderPrice(string $varName, Mailcode_Number_LocalCurrency $localCurrency, bool $absolute = false, bool $withCurrencyName = true): string
+    {
+        $varName = dollarize($varName);
+
+        if ($absolute) {
+            $varName = sprintf('${numeric.abs(%s)}', $varName);
+        }
+
+        $numberInfo = $localCurrency->getFormatInfo();
+
+        $displayedCurrency = $withCurrencyName
+            ? $localCurrency->getCurrencyName()
+            : $localCurrency->getCurrencySymbol();
+
+        return sprintf(
+            "money.amount(%s, '%s').group('%s').unit('%s', '%s').separator('%s')",
+            $varName,
+            $numberInfo->getDecimalsSeparator(),
+            $numberInfo->getThousandsSeparator(),
+            $displayedCurrency,
+            $localCurrency->getCountry(),
+            $localCurrency->getUnitSeparator()
         );
     }
 

--- a/src/Mailcode/Translator/Syntax/ApacheVelocity/ShowPriceTranslation.php
+++ b/src/Mailcode/Translator/Syntax/ApacheVelocity/ShowPriceTranslation.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @package Mailcode
+ * @subpackage Translator
+ */
+
+declare(strict_types=1);
+
+namespace Mailcode\Translator\Syntax\ApacheVelocity;
+
+use Mailcode\Mailcode_Commands_Command_ShowPrice;
+use Mailcode\Mailcode_Translator_Command_ShowPrice;
+use Mailcode\Translator\Syntax\ApacheVelocity;
+
+/**
+ * Translates the {@see Mailcode_Commands_Command_ShowPrice} command to Apache Velocity.
+ *
+ * @package Mailcode
+ * @subpackage Translator
+ * @author Olaf Böcker <olaf.boecker@ionos.com>
+ */
+class ShowPriceTranslation extends ApacheVelocity implements Mailcode_Translator_Command_ShowPrice
+{
+    public function translate(Mailcode_Commands_Command_ShowPrice $command): string
+    {
+        $statement = $this->renderPrice(
+            $command->getVariableName(),
+            $command->getLocalCurrency(),
+            $command->isAbsolute(),
+            $command->isCurrencyNameEnabled()
+        );
+
+        return $this->renderVariableEncodings($command, $statement);
+    }
+}

--- a/src/Mailcode/Translator/Syntax/ApacheVelocity/ShowPriceTranslation.php
+++ b/src/Mailcode/Translator/Syntax/ApacheVelocity/ShowPriceTranslation.php
@@ -23,9 +23,23 @@ class ShowPriceTranslation extends ApacheVelocity implements Mailcode_Translator
 {
     public function translate(Mailcode_Commands_Command_ShowPrice $command): string
     {
+        $localCurrency = $command->getLocalCurrency();
+
+        if ($command->isRegionPresent()) {
+            $regionToken = $command->getRegionToken();
+
+            $localCurrency = $localCurrency->withRegion($regionToken);
+        }
+
+        if ($command->isCurrencyPresent()) {
+            $currencyToken = $command->getCurrencyToken();
+
+            $localCurrency = $localCurrency->withCurrency($currencyToken);
+        }
+
         $statement = $this->renderPrice(
             $command->getVariableName(),
-            $command->getLocalCurrency(),
+            $localCurrency,
             $command->isAbsolute(),
             $command->isCurrencyNameEnabled()
         );

--- a/tests/testsuites/Commands/Types/ShowPriceTests.php
+++ b/tests/testsuites/Commands/Types/ShowPriceTests.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace testsuites\Commands\Types;
 
+use Mailcode\CurrencyInterface;
 use Mailcode\Interfaces\Commands\Validation\URLEncodingInterface;
 use Mailcode\Mailcode;
 use Mailcode\Mailcode_Commands_Command;
@@ -11,6 +12,7 @@ use Mailcode\Mailcode_Commands_Command_ShowNumber;
 use Mailcode\Mailcode_Commands_Command_ShowPrice;
 use Mailcode\Mailcode_Factory;
 use Mailcode\Mailcode_Commands_CommonConstants;
+use Mailcode\RegionInterface;
 use MailcodeTestCase;
 
 final class ShowPriceTests extends MailcodeTestCase
@@ -29,6 +31,24 @@ final class ShowPriceTests extends MailcodeTestCase
                 'string' => '{showprice: "Some text"}',
                 'valid' => false,
                 'code' => Mailcode_Commands_CommonConstants::VALIDATION_VARIABLE_MISSING
+            ),
+            array(
+                'label' => 'Invalid region type',
+                'string' => '{showprice: $FOO region=23}',
+                'valid' => false,
+                'code' => RegionInterface::VALIDATION_REGION_WRONG_TYPE
+            ),
+            array(
+                'label' => 'Invalid currency type',
+                'string' => '{showprice: $FOO currency=23}',
+                'valid' => false,
+                'code' => CurrencyInterface::VALIDATION_CURRENCY_WRONG_TYPE
+            ),
+            array(
+                'label' => 'Invalid currency type',
+                'string' => '{showprice: $FOO currency="de_DE" currency-name:}',
+                'valid' => false,
+                'code' => CurrencyInterface::VALIDATION_CURRENCY_EXCLUSIVE
             ),
             array(
                 'label' => 'With valid variable',
@@ -57,6 +77,24 @@ final class ShowPriceTests extends MailcodeTestCase
             array(
                 'label' => 'With valid variable, ignore string',
                 'string' => '{showprice: $FOO "banana"}',
+                'valid' => true,
+                'code' => 0
+            ),
+            array(
+                'label' => 'With valid variable, with region variable',
+                'string' => '{showprice: $FOO region=$FOO.REGION }',
+                'valid' => true,
+                'code' => 0
+            ),
+            array(
+                'label' => 'With valid variable, with region string, with currency string',
+                'string' => '{showprice: $FOO "banana" region="de_DE" currency="USD"}',
+                'valid' => true,
+                'code' => 0
+            ),
+            array(
+                'label' => 'With valid variable, with region variable, with currency variable',
+                'string' => '{showprice: $FOO "banana" region=$FOO.REGION currency=$FOO.CURRENCY}',
                 'valid' => true,
                 'code' => 0
             )
@@ -114,9 +152,54 @@ final class ShowPriceTests extends MailcodeTestCase
 
     public function test_absolute_normalized(): void
     {
-        $cmd = Mailcode_Factory::show()->price('foobar', true);
+        $cmd = Mailcode_Factory::show()->price('foobar', true, true);
 
         $this->assertTrue($cmd->isAbsolute());
         $this->assertSame('{showprice: $foobar absolute: currency-name:}', $cmd->getNormalized());
+    }
+
+    public function test_absolute_currency_string(): void
+    {
+        $cmd = Mailcode_Factory::show()->price('foobar', true, false, "USD");
+
+        $this->assertTrue($cmd->isAbsolute());
+        $this->assertSame('{showprice: $foobar absolute: currency="USD"}', $cmd->getNormalized());
+    }
+
+    public function test_absolute_currency_string_name(): void
+    {
+        $cmd = Mailcode_Factory::show()->price('foobar', true, true, "USD");
+
+        $this->assertTrue($cmd->isAbsolute());
+        $this->assertSame('{showprice: $foobar absolute: currency="USD"}', $cmd->getNormalized());
+    }
+
+    public function test_absolute_currency_variable(): void
+    {
+        $cmd = Mailcode_Factory::show()->price('foobar', true, true,
+            null, '$FOO.CURRENCY');
+
+        $this->assertTrue($cmd->isAbsolute());
+        $this->assertSame('{showprice: $foobar absolute: currency=$FOO.CURRENCY}', $cmd->getNormalized());
+    }
+
+    public function test_absolute_region_string(): void
+    {
+        $cmd = Mailcode_Factory::show()->price('foobar', true, true,
+            null, null,
+            "de_DE");
+
+        $this->assertTrue($cmd->isAbsolute());
+        $this->assertSame('{showprice: $foobar absolute: currency-name: region="de_DE"}', $cmd->getNormalized());
+    }
+
+    public function test_absolute_region_variable(): void
+    {
+        $cmd = Mailcode_Factory::show()->price('foobar', true, true,
+            null, null,
+            null, '$FOO.REGION');
+
+        $this->assertTrue($cmd->isAbsolute());
+        $this->assertSame('{showprice: $foobar absolute: currency-name: region=$FOO.REGION}', $cmd->getNormalized());
     }
 }

--- a/tests/testsuites/Commands/Types/ShowPriceTests.php
+++ b/tests/testsuites/Commands/Types/ShowPriceTests.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace testsuites\Commands\Types;
+
+use Mailcode\Interfaces\Commands\Validation\URLEncodingInterface;
+use Mailcode\Mailcode;
+use Mailcode\Mailcode_Commands_Command;
+use Mailcode\Mailcode_Commands_Command_ShowNumber;
+use Mailcode\Mailcode_Commands_Command_ShowPrice;
+use Mailcode\Mailcode_Factory;
+use Mailcode\Mailcode_Commands_CommonConstants;
+use MailcodeTestCase;
+
+final class ShowPriceTests extends MailcodeTestCase
+{
+    public function test_validation(): void
+    {
+        $tests = array(
+            array(
+                'label' => 'Without parameters',
+                'string' => '{showprice:}',
+                'valid' => false,
+                'code' => Mailcode_Commands_Command::VALIDATION_MISSING_PARAMETERS
+            ),
+            array(
+                'label' => 'Without variable',
+                'string' => '{showprice: "Some text"}',
+                'valid' => false,
+                'code' => Mailcode_Commands_CommonConstants::VALIDATION_VARIABLE_MISSING
+            ),
+            array(
+                'label' => 'With valid variable',
+                'string' => '{showprice: $FOO}',
+                'valid' => true,
+                'code' => 0
+            ),
+            array(
+                'label' => 'With valid variable, expect currency name',
+                'string' => '{showprice: $FOO currency-name:}',
+                'valid' => true,
+                'code' => 0
+            ),
+            array(
+                'label' => 'With valid variable, expect currency name, expect absolute',
+                'string' => '{showprice: $FOO currency-name: absolute:}',
+                'valid' => true,
+                'code' => 0
+            ),
+            array(
+                'label' => 'With valid variable, expect currency name, expect absolute, alternative order',
+                'string' => '{showprice: $FOO absolute: currency-name:}',
+                'valid' => true,
+                'code' => 0
+            ),
+            array(
+                'label' => 'With valid variable, ignore string',
+                'string' => '{showprice: $FOO "banana"}',
+                'valid' => true,
+                'code' => 0
+            )
+        );
+
+        $this->runCollectionTests($tests);
+    }
+
+    public function test_getFormat(): void
+    {
+        $cmd = Mailcode_Factory::show()->price('foobar');
+
+        $this->assertEquals('$foobar', $cmd->getVariable()->getFullName());
+        $this->assertEquals('1,000.00', $cmd->getLocalCurrency()->getFormatString());
+        $this->assertFalse($cmd->getLocalCurrency()->getFormatInfo()->hasPadding());
+    }
+
+    public function test_urlencode(): void
+    {
+        $cmd = Mailcode::create()
+            ->parseString('{showprice: $FOO urlencode:}')
+            ->getFirstCommand();
+
+        $this->assertInstanceOf(URLEncodingInterface::class, $cmd);
+        $this->assertTrue($cmd->isURLEncoded());
+    }
+
+    public function test_absolute_string(): void
+    {
+        $cmd = Mailcode::create()
+            ->parseString('{showprice: $FOO absolute:}')
+            ->getFirstCommand();
+
+        $this->assertInstanceOf(Mailcode_Commands_Command_ShowPrice::class, $cmd);
+        $this->assertTrue($cmd->isAbsolute());
+    }
+
+    public function test_absolute_default(): void
+    {
+        $cmd = Mailcode_Factory::show()->price('foobar');
+
+        $this->assertFalse($cmd->isAbsolute());
+    }
+
+    public function test_absolute_set(): void
+    {
+        $cmd = Mailcode_Factory::show()->price('foobar');
+
+        $cmd->setAbsolute(true);
+        $this->assertTrue($cmd->isAbsolute());
+
+        $cmd->setAbsolute(false);
+        $this->assertFalse($cmd->isAbsolute());
+    }
+
+    public function test_absolute_normalized(): void
+    {
+        $cmd = Mailcode_Factory::show()->price('foobar', true);
+
+        $this->assertTrue($cmd->isAbsolute());
+        $this->assertSame('{showprice: $foobar absolute: currency-name:}', $cmd->getNormalized());
+    }
+}

--- a/tests/testsuites/Factory/Commands/ShowNumber.php
+++ b/tests/testsuites/Factory/Commands/ShowNumber.php
@@ -12,7 +12,7 @@ final class Factory_ShowNumberTests extends FactoryTestCase
         return Mailcode_Commands_Command_ShowNumber::class;
     }
     
-    public function test_showVar() : void
+    public function test_showNumber() : void
     {
         $this->runCommand(
             'Variable name without $',
@@ -25,7 +25,7 @@ final class Factory_ShowNumberTests extends FactoryTestCase
         );
     }
     
-    public function test_showVar_error() : void
+    public function test_showNumber_error() : void
     {
         $this->expectException(Mailcode_Factory_Exception::class);
         

--- a/tests/testsuites/Factory/Commands/ShowPrice.php
+++ b/tests/testsuites/Factory/Commands/ShowPrice.php
@@ -1,0 +1,44 @@
+<?php
+
+use Mailcode\Mailcode_Commands_Command_ShowNumber;
+use Mailcode\Mailcode_Commands_Command_ShowPrice;
+use Mailcode\Mailcode_Factory;
+use Mailcode\Mailcode_Factory_Exception;
+use MailcodeTestClasses\FactoryTestCase;
+
+final class Factory_ShowPriceTests extends FactoryTestCase
+{
+    protected function getExpectedClass(): string
+    {
+        return Mailcode_Commands_Command_ShowPrice::class;
+    }
+
+    public function test_showPrice(): void
+    {
+        $this->runCommand(
+            'Variable name without $',
+            function () {
+                return Mailcode_Factory::show()->price('VAR.NAME');
+            }
+        );
+        $this->runCommand(
+            'Variable name with $',
+            function () {
+                return Mailcode_Factory::show()->price('$VAR.NAME');
+            }
+        );
+        $this->runCommand(
+            'Variable name with $, currency name',
+            function () {
+                return Mailcode_Factory::show()->price('$VAR.NAME');
+            }
+        );
+    }
+
+    public function test_showPrice_error(): void
+    {
+        $this->expectException(Mailcode_Factory_Exception::class);
+
+        Mailcode_Factory::show()->price('0INVALIDVAR');
+    }
+}

--- a/tests/testsuites/Numbers/NumberPriceTests.php
+++ b/tests/testsuites/Numbers/NumberPriceTests.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace testsuites\Numbers;
+
+use Mailcode\Mailcode_Number_LocalCurrency;
+use MailcodeTestCase;
+
+final class NumberPriceTests extends MailcodeTestCase
+{
+    public function test_localized_currency_basic(): void
+    {
+        $test = new Mailcode_Number_LocalCurrency("US", "USD", "$", " ", "1,000.00");
+
+        self::assertEquals('$', $test->getCurrencySymbol());
+        self::assertEquals('USD', $test->getCurrencyName());
+        self::assertEquals(' ', $test->getUnitSeparator());
+
+        self::assertEquals(',', $test->getFormatInfo()->getThousandsSeparator());
+        self::assertEquals('.', $test->getFormatInfo()->getDecimalsSeparator());
+
+        self::assertSame(2, $test->getFormatInfo()->getDecimals());
+        self::assertSame(0, $test->getFormatInfo()->getPadding());
+
+        self::assertTrue($test->getFormatInfo()->hasThousandsSeparator());
+        self::assertTrue($test->getFormatInfo()->hasDecimals());
+        self::assertFalse($test->getFormatInfo()->hasPadding());
+    }
+}

--- a/tests/testsuites/Translator/ApacheVelocityTests.php
+++ b/tests/testsuites/Translator/ApacheVelocityTests.php
@@ -255,4 +255,46 @@ ${CUSTOMER.CUSTOMER_ID}
 
         $this->assertEquals($expected, $result);
     }
+
+    public function test_showPrice_defaults(): void
+    {
+        $subject = '{showprice: $FOO.BAR}';
+
+        $expected = '${money.amount($FOO.BAR, ".").group(",").unit("$", "US").separator(" ")}';
+
+        $syntax = $this->translator->createApacheVelocity();
+        $safeguard = Mailcode::create()->createSafeguard($subject);
+
+        $result = $syntax->translateSafeguard($safeguard);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function test_showPrice_currencyName(): void
+    {
+        $subject = '{showprice: $FOO.BAR currency-name:}';
+
+        $expected = '${money.amount($FOO.BAR, ".").group(",").unit("USD", "US").separator(" ")}';
+
+        $syntax = $this->translator->createApacheVelocity();
+        $safeguard = Mailcode::create()->createSafeguard($subject);
+
+        $result = $syntax->translateSafeguard($safeguard);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function test_showPrice_region_variable(): void
+    {
+        $subject = '{showprice: $FOO.BAR region=$FOO.REGION}';
+
+        $expected = '${money.amount($FOO.BAR, ".").group(",").unit("$", $FOO.REGION).separator(" ")}';
+
+        $syntax = $this->translator->createApacheVelocity();
+        $safeguard = Mailcode::create()->createSafeguard($subject);
+
+        $result = $syntax->translateSafeguard($safeguard);
+
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/testsuites/Translator/Velocity/ShowPrice.php
+++ b/tests/testsuites/Translator/Velocity/ShowPrice.php
@@ -1,0 +1,39 @@
+<?php
+
+use Mailcode\Mailcode_Factory;
+use MailcodeTestClasses\VelocityTestCase;
+
+final class Translator_Velocity_ShowPriceTests extends VelocityTestCase
+{
+    public function test_translateCommand(): void
+    {
+        $tests = array(
+            array(
+                'label' => 'Default',
+                'mailcode' => Mailcode_Factory::show()
+                    ->price('FOO.BAR'),
+                'expected' => <<<'EOD'
+${money.amount($FOO.BAR, '.').group(',').unit('USD', 'US').separator(' ')}
+EOD
+            ),
+            array(
+                'label' => 'With absolute number',
+                'mailcode' => Mailcode_Factory::show()
+                    ->price('FOO.BAR', true),
+                'expected' => <<<'EOD'
+${money.amount(${numeric.abs($FOO.BAR)}, '.').group(',').unit('USD', 'US').separator(' ')}
+EOD
+            ),
+            array(
+                'label' => 'With currency symbol instead of name',
+                'mailcode' => Mailcode_Factory::show()
+                    ->price('FOO.BAR', false, false),
+                'expected' => <<<'EOD'
+${money.amount($FOO.BAR, '.').group(',').unit('$', 'US').separator(' ')}
+EOD
+            )
+        );
+
+        $this->runCommands($tests);
+    }
+}

--- a/tests/testsuites/Translator/Velocity/ShowPrice.php
+++ b/tests/testsuites/Translator/Velocity/ShowPrice.php
@@ -13,7 +13,7 @@ final class Translator_Velocity_ShowPriceTests extends VelocityTestCase
                 'mailcode' => Mailcode_Factory::show()
                     ->price('FOO.BAR'),
                 'expected' => <<<'EOD'
-${money.amount($FOO.BAR, '.').group(',').unit('USD', 'US').separator(' ')}
+${money.amount($FOO.BAR, ".").group(",").unit("$", "US").separator(" ")}
 EOD
             ),
             array(
@@ -21,15 +21,15 @@ EOD
                 'mailcode' => Mailcode_Factory::show()
                     ->price('FOO.BAR', true),
                 'expected' => <<<'EOD'
-${money.amount(${numeric.abs($FOO.BAR)}, '.').group(',').unit('USD', 'US').separator(' ')}
+${money.amount(${numeric.abs($FOO.BAR)}, ".").group(",").unit("$", "US").separator(" ")}
 EOD
             ),
             array(
-                'label' => 'With currency symbol instead of name',
+                'label' => 'With currency name instead of symbol',
                 'mailcode' => Mailcode_Factory::show()
-                    ->price('FOO.BAR', false, false),
+                    ->price('FOO.BAR', false, true),
                 'expected' => <<<'EOD'
-${money.amount($FOO.BAR, '.').group(',').unit('$', 'US').separator(' ')}
+${money.amount($FOO.BAR, ".").group(",").unit("USD", "US").separator(" ")}
 EOD
             )
         );


### PR DESCRIPTION
The `showprice` command allows formatting of monetary amounts using the proprietary `$money` tool.

Usage:
`{showprice: $FOO.BAR currency-name: absolute:}`

It depends on previous setup of the currency configuration that defines which country and currency (plus symbol and separators) are to be used. Expectation is that the Mail Editor will configure this similar to the timezone in the `showdate` command.

Other proposed functionalities are not part of this pull request yet, due to some conceptual questions:
- We will need to find a way to supply both currency "name" and "symbol" simultaneously to prevent inconsistent behaviour
  - should Mailcode be aware of which currencies exist and what symbol correspond?
- The `$money` tool has some rules built in concerning positioning of the currency in relation to the amount (before or after), so the `financial:` keyword will not work without alterations to the `$money` tool
- Providing a country in the command to determine the format string also implies that Mailcode is aware of country-specific settings, which so far is not.